### PR TITLE
test: verify detail route wrappers call APIs with route params

### DIFF
--- a/src/routes/wrappers/__tests__/DetailRoutes.test.tsx
+++ b/src/routes/wrappers/__tests__/DetailRoutes.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, waitFor } from '@testing-library/react';
+
+import { ArtistProfileRoute } from '../ArtistProfileRoute';
+import { EventDetailRoute } from '../EventDetailRoute';
+import { ProjectDetailRoute } from '../ProjectDetailRoute';
+import * as api from '@/services/api';
+
+jest.mock('@/lib/api/useCategories', () => ({
+  useCategories: () => ({ data: null }),
+}));
+
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: null, isAuthenticated: false }),
+}));
+
+describe('Detail route wrappers', () => {
+  beforeEach(() => {
+    jest.spyOn(window, 'alert').mockImplementation(() => undefined);
+    jest.spyOn(window.history, 'back').mockImplementation(() => undefined as never);
+    jest.spyOn(window, 'open').mockImplementation(() => null);
+    Object.assign(navigator, {
+      share: jest.fn(),
+      clipboard: { writeText: jest.fn() },
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('calls artist API with handle from params', async () => {
+    const getArtistSpy = jest
+      .spyOn(api.artistAPI, 'getArtistById')
+      .mockResolvedValue({
+        success: true,
+        data: {
+          coverImage: '',
+          name: '테스트 아티스트',
+          category: '음악',
+          username: 'artist123',
+          bio: '소개',
+          location: '서울',
+          joinDate: '2024-01-01',
+          website: 'https://example.com',
+          tags: [],
+          followers: 0,
+          posts: 0,
+          following: 0,
+          profileImage: '',
+          activeProject: null,
+        },
+      } as any);
+
+    render(
+      <MemoryRouter initialEntries={['/artists/42']}>
+        <Routes>
+          <Route path="/artists/:handle" element={<ArtistProfileRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getArtistSpy).toHaveBeenCalledWith('42');
+    });
+  });
+
+  it('calls project API with slug from params', async () => {
+    jest.spyOn(api.fundingAPI, 'backProject').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.fundingAPI, 'likeProject').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.fundingAPI, 'bookmarkProject').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.interactionAPI, 'followArtist').mockResolvedValue({ success: true } as any);
+
+    const getProjectSpy = jest.spyOn(api.fundingAPI, 'getProject').mockResolvedValue({
+      success: true,
+      data: {
+        image: '',
+        title: '테스트 프로젝트',
+        featured: false,
+        category: '예술',
+        artistAvatar: '',
+        artist: '테스트 아티스트',
+        artistRating: 4.5,
+        artistId: 1,
+        description: '설명',
+        currentAmount: 0,
+        targetAmount: 100,
+        backers: 0,
+        daysLeft: 10,
+        story: '스토리',
+        rewards: [],
+        updates: [],
+        comments: [],
+      },
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={['/projects/123']}>
+        <Routes>
+          <Route path="/projects/:slug" element={<ProjectDetailRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getProjectSpy).toHaveBeenCalledWith('123');
+    });
+  });
+
+  it('calls event API with id from params', async () => {
+    jest.spyOn(api.eventManagementAPI, 'joinEvent').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.eventManagementAPI, 'leaveEvent').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.eventManagementAPI, 'likeEvent').mockResolvedValue({ success: true } as any);
+    jest.spyOn(api.eventManagementAPI, 'bookmarkEvent').mockResolvedValue({ success: true } as any);
+
+    const getEventSpy = jest.spyOn(api.eventManagementAPI, 'getEvent').mockResolvedValue({
+      success: true,
+      data: {
+        title: '테스트 이벤트',
+        coverImage: '',
+        status: 'upcoming',
+        startDate: '2024-01-01',
+        endDate: '2024-01-02',
+        location: '서울',
+        time: '18:00',
+        capacity: 100,
+        participants: [],
+        description: '이벤트 설명',
+        agenda: [],
+        speaker: {
+          name: '연사',
+          role: '주최자',
+          avatar: '',
+        },
+        tags: [],
+      },
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={['/events/alpha']}>
+        <Routes>
+          <Route path="/events/:id" element={<EventDetailRoute />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(getEventSpy).toHaveBeenCalledWith('alpha');
+    });
+  });
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 작업 개요
- **변경 사항**: 디테일 페이지용 라우트 래퍼를 메모리 라우터 환경에서 렌더링해 각각의 서비스 API가 올바른 파라미터로 호출되는지 확인하는 단위 테스트를 추가했습니다.
- **관련 이슈**: N/A
- **타입**: test

## 🔄 주요 변경 사항
- [ ] UI/UX 변경 (스크린샷 첨부)
- [ ] API 계약/훅 변경 (영향 범위 명시)
- [ ] 데이터베이스 스키마 변경
- [ ] 새로운 의존성 추가
- [ ] 환경 변수 변경
- [ ] 접근성/성능 고려사항

## 🧪 테스트
### 테스트 시나리오
- [x] 새로운 기능 테스트
- [ ] 기존 기능 회귀 테스트
- [ ] 에지 케이스 테스트
- [ ] 성능 테스트 (필요시)

### 테스트 결과
- `npm test -- DetailRoutes` 명령을 실행하려 했으나, 패키지 설치 과정에서 `eslint` 패키지에 대한 403 Forbidden 에러로 인해 의존성 설치가 완료되지 못해 테스트를 수행하지 못했습니다. (환경 제한)

## 📸 스크린샷 (UI 변경시)
N/A

## ⚠️ 주의사항
- 배포 시 주의 사항 없음
- 롤백 계획: 테스트 파일 제거 후 롤백 가능
- 데이터 마이그레이션 필요 없음

## ✅ 완료 전 점검 (체크 후 진행)
### 코드 품질
- [ ] 타입/빌드 에러 없음 (`npm run check:types`, `check:build`)
- [ ] 린트/포맷 통과 (`check:lint`, `check:format`)
- [ ] 테스트/접근성 통과 (`check:test`, `check:accessibility`)
- [ ] 미사용 코드/의존성/스크립트 없음 (`check:deadcode`, `check:deps`)
- [ ] 색상 하드코딩 없음 (`check:colors`)

### 문서화
- [ ] README 업데이트 (필요시)
- [ ] API 문서 업데이트 (필요시)
- [ ] 주석 추가/수정 (복잡한 로직)

### 보안
- [x] 민감한 정보 하드코딩 없음
- [ ] 입력 검증 적절히 구현
- [ ] 권한 체크 로직 검토

## 🔗 관련 링크
- [Figma 디자인](링크)
- [API 문서](링크)
- [관련 이슈](링크)

------
https://chatgpt.com/codex/tasks/task_b_68cdf16f7fdc8326a344ae1578337655