### PR TITLE
refactor: modularize community routes

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,9 +1,18 @@
+const createTransformConfig = () => {
+  try {
+    require.resolve('ts-jest');
+    return {
+      '^.+\\.(t|j)sx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
+    };
+  } catch (_error) {
+    return {};
+  }
+};
+
 module.exports = {
   testEnvironment: 'node',
   reporters: ['default', ['jest-junit', { outputDirectory: 'reports/junit' }]],
-  transform: {
-    '^.+\\.(t|j)sx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }]
-  },
+  transform: createTransformConfig(),
   testMatch: [
     '**/tests/**/*.(ts|js)',
     '**/*.(test|spec).(ts|js)',

--- a/server/routes/community.js
+++ b/server/routes/community.js
@@ -1,949 +1,126 @@
 const express = require('express');
+const mongoose = require('mongoose');
 const router = express.Router();
-const CommunityPost = require('../models/CommunityPost');
 const auth = require('../middleware/auth');
+const communityController = require('../src/controllers/communityController');
 
-// 디버그용 테스트 엔드포인트
-router.get('/posts/test', async (req, res) => {
-  res.json({
-    success: true,
-    message: '테스트 엔드포인트 작동 중',
-    timestamp: new Date().toISOString()
-  });
-});
+const validateObjectIdParam = (param, message) => (req, res, next) => {
+  const value = req.params[param];
 
-// 카테고리 목록 조회
-router.get('/categories', async (req, res) => {
-  try {
-    const categories = [
-      { value: '자유', label: '자유', color: 'bg-blue-100 text-blue-700' },
-      { value: '질문', label: '질문', color: 'bg-yellow-100 text-yellow-700' },
-      { value: '음악', label: '음악', color: 'bg-purple-100 text-purple-700' },
-      { value: '미술', label: '미술', color: 'bg-pink-100 text-pink-700' },
-      { value: '문학', label: '문학', color: 'bg-green-100 text-green-700' },
-      { value: '공연', label: '공연', color: 'bg-orange-100 text-orange-700' },
-      { value: '사진', label: '사진', color: 'bg-indigo-100 text-indigo-700' },
-      { value: '기술', label: '기술', color: 'bg-cyan-100 text-cyan-700' },
-      { value: '기타', label: '기타', color: 'bg-gray-100 text-gray-700' }
-    ];
-
-    res.json({
-      success: true,
-      data: categories
-    });
-  } catch (error) {
-    console.error('카테고리 조회 실패:', error);
-    res.status(500).json({
+  if (!mongoose.Types.ObjectId.isValid(value)) {
+    return res.status(400).json({
       success: false,
-      message: '카테고리를 불러올 수 없습니다.'
+      message
     });
   }
-});
 
-// 커뮤니티 포스트 목록 조회
-router.get('/posts', async (req, res) => {
-  try {
-    const { page = 1, limit = 20, search = '', category = '', sortBy = 'latest' } = req.query;
-    
-    const query = { isActive: true };
-    if (search) {
-      query.$or = [
-        { title: { $regex: search, $options: 'i' } },
-        { content: { $regex: search, $options: 'i' } },
-        { tags: { $in: [new RegExp(search, 'i')] } }
-      ];
-    }
-    if (category && category !== 'all') query.category = category;
+  next();
+};
 
-    const skip = (parseInt(page) - 1) * parseInt(limit);
-    
-    let sortQuery = {};
-    switch (sortBy) {
-      case 'latest':
-        sortQuery = { createdAt: -1 };
-        break;
-      case 'popular':
-        sortQuery = { likes: -1, viewCount: -1 };
-        break;
-      case 'oldest':
-        sortQuery = { createdAt: 1 };
-        break;
-      default:
-        sortQuery = { createdAt: -1 };
-    }
-    
-    const posts = await CommunityPost.find(query)
-      .populate('author', 'name role avatar')
-      .sort(sortQuery)
-      .skip(skip)
-      .limit(parseInt(limit));
+const validateCreatePost = (req, res, next) => {
+  const { title, content, category } = req.body;
 
-    const total = await CommunityPost.countDocuments(query);
-
-    res.json({
-      success: true,
-      posts: posts,
-      pagination: {
-        page: parseInt(page),
-        limit: parseInt(limit),
-        total,
-        pages: Math.ceil(total / parseInt(limit))
-      }
-    });
-  } catch (error) {
-    console.error('커뮤니티 포스트 조회 실패:', error);
-    res.status(500).json({
+  if (!title || !content || !category) {
+    return res.status(400).json({
       success: false,
-      message: '커뮤니티 포스트를 불러올 수 없습니다.'
+      message: '제목, 내용, 카테고리는 필수입니다.'
     });
   }
-});
 
-// 인기 게시글 조회 (구체적인 라우트를 먼저 정의)
-router.get('/posts/popular', async (req, res) => {
-  try {
-    const { limit = 10 } = req.query;
-    
-    const posts = await CommunityPost.find({ isActive: true })
-      .populate('author', 'name role avatar')
-      .sort({ likes: -1, viewCount: -1 })
-      .limit(parseInt(limit));
+  next();
+};
 
-    res.json({
-      success: true,
-      data: posts
-    });
-  } catch (error) {
-    console.error('인기 게시글 조회 실패:', error);
-    res.status(500).json({
+const validateReactionBody = (req, res, next) => {
+  const { reaction } = req.body;
+
+  if (!reaction) {
+    return res.status(400).json({
       success: false,
-      message: '인기 게시글을 불러올 수 없습니다.'
+      message: '반응 타입을 지정해주세요.'
     });
   }
-});
 
-// 최신 게시글 조회 (구체적인 라우트를 먼저 정의)
-router.get('/posts/recent', async (req, res) => {
-  try {
-    const { limit = 10 } = req.query;
-    
-    const posts = await CommunityPost.find({ isActive: true })
-      .populate('author', 'name role avatar')
-      .sort({ createdAt: -1 })
-      .limit(parseInt(limit));
+  next();
+};
 
-    res.json({
-      success: true,
-      data: posts
-    });
-  } catch (error) {
-    console.error('최신 게시글 조회 실패:', error);
-    res.status(500).json({
+const validateReportBody = (req, res, next) => {
+  const { reason } = req.body;
+
+  if (!reason) {
+    return res.status(400).json({
       success: false,
-      message: '최신 게시글을 불러올 수 없습니다.'
+      message: '신고 사유를 입력해주세요.'
     });
   }
-});
 
-// 특정 포스트 조회 (일반적인 라우트는 나중에 정의)
-router.get('/posts/:id', async (req, res) => {
-  console.log('=== 포스트 조회 라우트 진입 ===');
-  console.log('요청 URL:', req.url);
-  console.log('요청 파라미터:', req.params);
-  console.log('요청 쿼리:', req.query);
-  
-  try {
-    const { id } = req.params;
-    console.log('포스트 조회 요청:', { id, timestamp: new Date().toISOString() });
-    
-    // ObjectId 유효성 검사
-    if (!id || id.length !== 24) {
-      console.log('유효하지 않은 ObjectId:', id);
-      return res.status(400).json({
-        success: false,
-        message: '유효하지 않은 포스트 ID입니다.'
-      });
-    }
+  next();
+};
 
-    console.log('데이터베이스 쿼리 시작...');
-    const post = await CommunityPost.findById(id)
-      .populate('author', 'name role avatar')
-      .populate('comments.author', 'name role avatar');
+const validateCommentBody = (req, res, next) => {
+  const { content } = req.body;
 
-    console.log('데이터베이스 쿼리 완료');
-    console.log('조회된 포스트:', post ? `존재함 (ID: ${post._id})` : '없음');
-
-    if (!post) {
-      console.log('포스트를 찾을 수 없음:', id);
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    if (!post.isActive) {
-      console.log('비활성 포스트:', id);
-      return res.status(404).json({
-        success: false,
-        message: '삭제된 포스트입니다.'
-      });
-    }
-
-    // 조회수 증가
-    post.viewCount += 1;
-    await post.save();
-    console.log('조회수 증가 완료:', post.viewCount);
-
-    console.log('응답 전송 중...');
-    res.json({
-      success: true,
-      data: post
-    });
-    console.log('응답 전송 완료');
-  } catch (error) {
-    console.error('포스트 조회 실패:', {
-      error: error.message,
-      stack: error.stack,
-      id: req.params.id,
-      timestamp: new Date().toISOString()
-    });
-    res.status(500).json({
+  if (!content || content.trim().length === 0) {
+    return res.status(400).json({
       success: false,
-      message: '포스트를 불러올 수 없습니다.',
-      error: process.env.NODE_ENV === 'development' ? error.message : undefined
+      message: '댓글 내용을 입력해주세요.'
     });
   }
-});
 
-// 포스트 조회수 증가 (별도 엔드포인트)
-router.post('/posts/:id/views', async (req, res) => {
-  try {
-    const { id } = req.params;
-    console.log('조회수 증가 요청:', { id });
-    
-    const post = await CommunityPost.findById(id);
-    console.log('조회된 포스트:', post ? '존재함' : '없음');
-
-    if (!post) {
-      console.log('포스트를 찾을 수 없음:', id);
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    if (!post.isActive) {
-      console.log('비활성 포스트:', id);
-      return res.status(404).json({
-        success: false,
-        message: '삭제된 포스트입니다.'
-      });
-    }
-
-    // 조회수 증가
-    post.viewCount += 1;
-    await post.save();
-    console.log('조회수 증가 완료:', post.viewCount);
-
-    res.json({
-      success: true,
-      message: '조회수가 증가되었습니다.',
-      data: {
-        views: post.viewCount
-      }
-    });
-  } catch (error) {
-    console.error('조회수 증가 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '조회수 증가에 실패했습니다.',
-      error: process.env.NODE_ENV === 'development' ? error.message : undefined
-    });
-  }
-});
-
-// 포스트 사용자별 반응 상태 확인
-router.get('/posts/:id/reactions', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const userId = req.user._id;
-    
-    const post = await CommunityPost.findById(id);
-    if (!post) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-    
-    const isLiked = post.likes.includes(userId);
-    const isDisliked = post.dislikes.includes(userId);
-    
-    res.json({
-      success: true,
-      data: {
-        isLiked,
-        isDisliked,
-        likes: post.likes.length,
-        dislikes: post.dislikes.length
-      }
-    });
-  } catch (error) {
-    console.error('반응 상태 확인 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '반응 상태 확인에 실패했습니다.'
-    });
-  }
-});
-
-// 포스트 생성 (인증 필요)
-router.post('/posts', auth, async (req, res) => {
-  try {
-    const { title, content, category, tags, images, authorName } = req.body;
-    const author = req.user._id;
-
-    console.log('포스트 생성 요청 데이터:', { title, content, category, tags, images, authorName, author });
-
-    if (!title || !content || !category) {
-      return res.status(400).json({
-        success: false,
-        message: '제목, 내용, 카테고리는 필수입니다.'
-      });
-    }
-
-    const post = new CommunityPost({
-      title,
-      content,
-      category,
-      tags: tags || [],
-      images: images || [],
-      author,
-      authorName: authorName || '사용자'
-    });
-
-    await post.save();
-
-    const populatedPost = await CommunityPost.findById(post._id)
-      .populate('author', 'name role avatar');
-
-    res.status(201).json({
-      success: true,
-      data: populatedPost,
-      message: '포스트가 생성되었습니다.'
-    });
-  } catch (error) {
-    console.error('포스트 생성 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '포스트를 생성할 수 없습니다.',
-      error: error.message
-    });
-  }
-});
-
-// 포스트 수정 (인증 필요)
-router.put('/posts/:id', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const { title, content, category, tags } = req.body;
-    const userId = req.user._id;
-
-    const post = await CommunityPost.findById(id);
-    if (!post) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    if (post.author.toString() !== userId && req.user.role !== 'admin') {
-      return res.status(403).json({
-        success: false,
-        message: '포스트를 수정할 권한이 없습니다.'
-      });
-    }
-
-    post.title = title || post.title;
-    post.content = content || post.content;
-    post.category = category || post.category;
-    post.tags = tags || post.tags;
-    post.updatedAt = new Date();
-
-    await post.save();
-
-    const updatedPost = await CommunityPost.findById(id)
-      .populate('author', 'name role avatar');
-
-    res.json({
-      success: true,
-      data: updatedPost,
-      message: '포스트가 수정되었습니다.'
-    });
-  } catch (error) {
-    console.error('포스트 수정 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '포스트를 수정할 수 없습니다.'
-    });
-  }
-});
-
-// 포스트 삭제 (인증 필요)
-router.delete('/posts/:id', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const userId = req.user._id;
-
-    const post = await CommunityPost.findById(id);
-    if (!post) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    if (post.author.toString() !== userId && req.user.role !== 'admin') {
-      return res.status(403).json({
-        success: false,
-        message: '포스트를 삭제할 권한이 없습니다.'
-      });
-    }
-
-    // 실제 삭제 대신 비활성화
-    post.isActive = false;
-    post.deletedAt = new Date();
-    await post.save();
-
-    res.json({
-      success: true,
-      message: '포스트가 삭제되었습니다.'
-    });
-  } catch (error) {
-    console.error('포스트 삭제 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '포스트를 삭제할 수 없습니다.'
-    });
-  }
-});
-
-// 포스트 좋아요/싫어요 (인증 필요)
-router.post('/posts/:id/reactions', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const { reaction } = req.body; // 'like', 'dislike', 'unlike', 'undislike'
-    const userId = req.user._id;
-
-    if (!['like', 'dislike', 'unlike', 'undislike'].includes(reaction)) {
-      return res.status(400).json({
-        success: false,
-        message: '유효하지 않은 반응 타입입니다.'
-      });
-    }
-
-    const post = await CommunityPost.findById(id);
-    if (!post) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 현재 사용자의 반응 상태 확인
-    const isLiked = post.likes.includes(userId);
-    const isDisliked = post.dislikes.includes(userId);
-
-    // 반응 처리 로직
-    if (reaction === 'like') {
-      if (isLiked) {
-        // 이미 좋아요를 누른 상태면 취소
-        post.likes = post.likes.filter(id => id.toString() !== userId);
-      } else {
-        // 좋아요 추가하고 싫어요 제거 (상호 배타적)
-        post.likes.push(userId);
-        post.dislikes = post.dislikes.filter(id => id.toString() !== userId);
-      }
-    } else if (reaction === 'dislike') {
-      if (isDisliked) {
-        // 이미 싫어요를 누른 상태면 취소
-        post.dislikes = post.dislikes.filter(id => id.toString() !== userId);
-      } else {
-        // 싫어요 추가하고 좋아요 제거 (상호 배타적)
-        post.dislikes.push(userId);
-        post.likes = post.likes.filter(id => id.toString() !== userId);
-      }
-    } else if (reaction === 'unlike') {
-      // 좋아요만 취소 (싫어요는 유지)
-      post.likes = post.likes.filter(id => id.toString() !== userId);
-    } else if (reaction === 'undislike') {
-      // 싫어요만 취소 (좋아요는 유지)
-      post.dislikes = post.dislikes.filter(id => id.toString() !== userId);
-    }
-
-    await post.save();
-
-    // 업데이트된 사용자 반응 상태 확인
-    const updatedIsLiked = post.likes.includes(userId);
-    const updatedIsDisliked = post.dislikes.includes(userId);
-
-    res.json({
-      success: true,
-      data: {
-        likes: post.likes.length,
-        dislikes: post.dislikes.length,
-        isLiked: updatedIsLiked,
-        isDisliked: updatedIsDisliked
-      },
-      message: '반응이 업데이트되었습니다.'
-    });
-  } catch (error) {
-    console.error('포스트 반응 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '반응을 처리할 수 없습니다.'
-    });
-  }
-});
-
-// 포스트 신고 (인증 필요)
-router.post('/posts/:id/report', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const { reason } = req.body;
-    const userId = req.user._id;
-
-    if (!reason) {
-      return res.status(400).json({
-        success: false,
-        message: '신고 사유를 입력해주세요.'
-      });
-    }
-
-    const post = await CommunityPost.findById(id);
-    if (!post) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 이미 신고된 경우
-    if (post.reports.some(report => report.reporter.toString() === userId)) {
-      return res.status(400).json({
-        success: false,
-        message: '이미 신고한 포스트입니다.'
-      });
-    }
-
-    post.reports.push({
-      reporter: userId,
-      reason,
-      reportedAt: new Date()
-    });
-
-    // 신고 횟수가 임계값을 넘으면 자동으로 비활성화
-    if (post.reports.length >= 5) {
-      post.isActive = false;
-      post.isReported = true;
-    }
-
-    await post.save();
-
-    res.json({
-      success: true,
-      message: '포스트가 신고되었습니다.'
-    });
-  } catch (error) {
-    console.error('포스트 신고 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '포스트를 신고할 수 없습니다.'
-    });
-  }
-});
-
-// 댓글 목록 조회
-router.get('/posts/:id/comments', async (req, res) => {
-  try {
-    const { id } = req.params;
-    const { page = 1, limit = 20, sortBy = 'createdAt', order = 'desc' } = req.query;
-
-    // 포스트 존재 확인
-    const post = await CommunityPost.findById(id);
-    if (!post || !post.isActive) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 정렬 옵션
-    const sortOption = {};
-    sortOption[sortBy] = order === 'desc' ? -1 : 1;
-
-    // 페이지네이션
-    const skip = (parseInt(page) - 1) * parseInt(limit);
-
-    // 댓글 조회 (대댓글 포함)
-    const comments = await CommunityPost.findById(id)
-      .select('comments')
-      .populate('comments.author', 'name role avatar')
-      .populate('comments.replies.author', 'name role avatar')
-      .lean();
-
-    if (!comments) {
-      return res.json({
-        success: true,
-        data: [],
-        pagination: {
-          page: parseInt(page),
-          limit: parseInt(limit),
-          total: 0,
-          pages: 0
-        }
-      });
-    }
-
-    // 댓글 정렬 및 페이지네이션
-    const sortedComments = comments.comments
-      .sort((a, b) => {
-        if (sortBy === 'createdAt') {
-          return order === 'desc' ? new Date(b.createdAt) - new Date(a.createdAt) : new Date(a.createdAt) - new Date(b.createdAt);
-        }
-        return 0;
-      })
-      .slice(skip, skip + parseInt(limit));
-
-    res.json({
-      success: true,
-      data: sortedComments,
-      pagination: {
-        page: parseInt(page),
-        limit: parseInt(limit),
-        total: comments.comments.length,
-        pages: Math.ceil(comments.comments.length / parseInt(limit))
-      }
-    });
-
-  } catch (error) {
-    console.error('댓글 조회 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '댓글을 불러올 수 없습니다.'
-    });
-  }
-});
-
-// 댓글 작성
-router.post('/posts/:id/comments', auth, async (req, res) => {
-  try {
-    const { id } = req.params;
-    const { content, parentId } = req.body;
-    const userId = req.user._id;
-
-    if (!content || content.trim().length === 0) {
-      return res.status(400).json({
-        success: false,
-        message: '댓글 내용을 입력해주세요.'
-      });
-    }
-
-    // 포스트 존재 확인
-    const post = await CommunityPost.findById(id);
-    if (!post || !post.isActive) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    const newComment = {
-      author: userId,
-      content: content.trim(),
-      parentId: parentId || null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      likes: [],
-      dislikes: [],
-      replies: []
-    };
-
-    if (parentId) {
-      // 대댓글인 경우
-      const parentComment = post.comments.id(parentId);
-      if (!parentComment) {
-        return res.status(404).json({
-          success: false,
-          message: '상위 댓글을 찾을 수 없습니다.'
-        });
-      }
-      parentComment.replies.push(newComment);
-    } else {
-      // 일반 댓글인 경우
-      post.comments.push(newComment);
-    }
-
-    await post.save();
-
-    // 작성된 댓글 정보와 함께 반환
-    const populatedPost = await CommunityPost.findById(id)
-      .populate('comments.author', 'name role avatar')
-      .populate('comments.replies.author', 'name role avatar');
-
-    const savedComment = parentId 
-      ? populatedPost.comments.id(parentId).replies[populatedPost.comments.id(parentId).replies.length - 1]
-      : populatedPost.comments[populatedPost.comments.length - 1];
-
-    res.status(201).json({
-      success: true,
-      message: '댓글이 작성되었습니다.',
-      data: savedComment
-    });
-
-  } catch (error) {
-    console.error('댓글 작성 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '댓글 작성에 실패했습니다.'
-    });
-  }
-});
-
-// 댓글 수정
-router.put('/posts/:id/comments/:commentId', auth, async (req, res) => {
-  try {
-    const { id, commentId } = req.params;
-    const { content } = req.body;
-    const userId = req.user._id;
-
-    if (!content || content.trim().length === 0) {
-      return res.status(400).json({
-        success: false,
-        message: '댓글 내용을 입력해주세요.'
-      });
-    }
-
-    // 포스트 존재 확인
-    const post = await CommunityPost.findById(id);
-    if (!post || !post.isActive) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 댓글 찾기 (일반 댓글 또는 대댓글)
-    let comment = post.comments.id(commentId);
-    let _isReply = false;
-
-    if (!comment) {
-      // 대댓글인지 확인
-      for (const parentComment of post.comments) {
-        comment = parentComment.replies.id(commentId);
-        if (comment) {
-          _isReply = true;
-          break;
-        }
-      }
-    }
-
-    if (!comment) {
-      return res.status(404).json({
-        success: false,
-        message: '댓글을 찾을 수 없습니다.'
-      });
-    }
-
-    // 권한 확인 (작성자 또는 관리자)
-    if (comment.author.toString() !== userId && req.user.role !== 'admin') {
-      return res.status(403).json({
-        success: false,
-        message: '댓글을 수정할 권한이 없습니다.'
-      });
-    }
-
-    // 댓글 수정
-    comment.content = content.trim();
-    comment.updatedAt = new Date();
-
-    await post.save();
-
-    res.json({
-      success: true,
-      message: '댓글이 수정되었습니다.',
-      data: comment
-    });
-
-  } catch (error) {
-    console.error('댓글 수정 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '댓글 수정에 실패했습니다.'
-    });
-  }
-});
-
-// 댓글 삭제
-router.delete('/posts/:id/comments/:commentId', auth, async (req, res) => {
-  try {
-    const { id, commentId } = req.params;
-    const userId = req.user._id;
-
-    // 포스트 존재 확인
-    const post = await CommunityPost.findById(id);
-    if (!post || !post.isActive) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 댓글 찾기 (일반 댓글 또는 대댓글)
-    let comment = post.comments.id(commentId);
-    let _isReply = false;
-    let parentComment = null;
-
-    if (!comment) {
-      // 대댓글인지 확인
-      for (const pc of post.comments) {
-        comment = pc.replies.id(commentId);
-        if (comment) {
-          _isReply = true;
-          parentComment = pc;
-          break;
-        }
-      }
-    }
-
-    if (!comment) {
-      return res.status(404).json({
-        success: false,
-        message: '댓글을 찾을 수 없습니다.'
-      });
-    }
-
-    // 권한 확인 (작성자 또는 관리자)
-    if (comment.author.toString() !== userId && req.user.role !== 'admin') {
-      return res.status(403).json({
-        success: false,
-        message: '댓글을 삭제할 권한이 없습니다.'
-      });
-    }
-
-    // 댓글 삭제
-    if (_isReply && parentComment) {
-      parentComment.replies.pull(commentId);
-    } else {
-      post.comments.pull(commentId);
-    }
-
-    await post.save();
-
-    res.json({
-      success: true,
-      message: '댓글이 삭제되었습니다.'
-    });
-
-  } catch (error) {
-    console.error('댓글 삭제 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '댓글 삭제에 실패했습니다.'
-    });
-  }
-});
-
-// 댓글 반응 (좋아요/싫어요)
-router.post('/posts/:id/comments/:commentId/reactions', auth, async (req, res) => {
-  try {
-    const { id, commentId } = req.params;
-    const { reaction } = req.body; // 'like', 'dislike', 또는 'unlike'
-    const userId = req.user._id;
-
-    if (!['like', 'dislike', 'unlike'].includes(reaction)) {
-      return res.status(400).json({
-        success: false,
-        message: '유효하지 않은 반응 타입입니다.'
-      });
-    }
-
-    // 포스트 존재 확인
-    const post = await CommunityPost.findById(id);
-    if (!post || !post.isActive) {
-      return res.status(404).json({
-        success: false,
-        message: '포스트를 찾을 수 없습니다.'
-      });
-    }
-
-    // 댓글 찾기 (일반 댓글 또는 대댓글)
-    let comment = post.comments.id(commentId);
-    let _isReply = false;
-
-    if (!comment) {
-      // 대댓글인지 확인
-      for (const parentComment of post.comments) {
-        comment = parentComment.replies.id(commentId);
-        if (comment) {
-          _isReply = true;
-          break;
-        }
-      }
-    }
-
-    if (!comment) {
-      return res.status(404).json({
-        success: false,
-        message: '댓글을 찾을 수 없습니다.'
-      });
-    }
-
-    // 반응 처리
-    if (reaction === 'like') {
-      // 좋아요 처리
-      if (comment.likes.includes(userId)) {
-        comment.likes.pull(userId);
-      } else {
-        comment.likes.push(userId);
-        comment.dislikes.pull(userId); // 싫어요에서 제거
-      }
-    } else if (reaction === 'dislike') {
-      // 싫어요 처리
-      if (comment.dislikes.includes(userId)) {
-        comment.dislikes.pull(userId);
-      } else {
-        comment.dislikes.push(userId);
-        comment.likes.pull(userId); // 좋아요에서 제거
-      }
-    } else if (reaction === 'unlike') {
-      // unlike는 현재 좋아요 상태를 토글 (좋아요 취소)
-      if (comment.likes.includes(userId)) {
-        comment.likes.pull(userId);
-      }
-      // 싫어요도 함께 제거 (unlike는 모든 반응 제거)
-      comment.dislikes.pull(userId);
-    }
-
-    await post.save();
-
-    res.json({
-      success: true,
-      message: '반응이 업데이트되었습니다.',
-      data: {
-        likes: comment.likes.length,
-        dislikes: comment.dislikes.length
-      }
-    });
-
-  } catch (error) {
-    console.error('댓글 반응 실패:', error);
-    res.status(500).json({
-      success: false,
-      message: '반응 처리에 실패했습니다.'
-    });
-  }
-});
-
+  next();
+};
+
+const validatePostId = validateObjectIdParam('id', '유효하지 않은 포스트 ID입니다.');
+const validateCommentId = validateObjectIdParam('commentId', '유효하지 않은 댓글 ID입니다.');
+
+router.get('/posts/test', communityController.getTestStatus);
+router.get('/categories', communityController.getCategories);
+router.get('/posts', communityController.getPosts);
+router.get('/posts/popular', communityController.getPopularPosts);
+router.get('/posts/recent', communityController.getRecentPosts);
+router.get('/posts/:id', validatePostId, communityController.getPostById);
+router.post('/posts/:id/views', validatePostId, communityController.incrementPostView);
+router.get('/posts/:id/reactions', auth, validatePostId, communityController.getPostReactions);
+router.post('/posts', auth, validateCreatePost, communityController.createPost);
+router.put('/posts/:id', auth, validatePostId, communityController.updatePost);
+router.delete('/posts/:id', auth, validatePostId, communityController.deletePost);
+router.post(
+  '/posts/:id/reactions',
+  auth,
+  validatePostId,
+  validateReactionBody,
+  communityController.updatePostReaction
+);
+router.post('/posts/:id/report', auth, validatePostId, validateReportBody, communityController.reportPost);
+router.get('/posts/:id/comments', validatePostId, communityController.getComments);
+router.post(
+  '/posts/:id/comments',
+  auth,
+  validatePostId,
+  validateCommentBody,
+  communityController.addComment
+);
+router.put(
+  '/posts/:id/comments/:commentId',
+  auth,
+  validatePostId,
+  validateCommentId,
+  validateCommentBody,
+  communityController.updateComment
+);
+router.delete(
+  '/posts/:id/comments/:commentId',
+  auth,
+  validatePostId,
+  validateCommentId,
+  communityController.deleteComment
+);
+router.post(
+  '/posts/:id/comments/:commentId/reactions',
+  auth,
+  validatePostId,
+  validateCommentId,
+  validateReactionBody,
+  communityController.reactToComment
+);
 
 module.exports = router;

--- a/server/src/controllers/__tests__/communityController.test.js
+++ b/server/src/controllers/__tests__/communityController.test.js
@@ -1,0 +1,97 @@
+jest.mock('../../services/communityService', () => ({
+  getCategories: jest.fn(),
+  getPosts: jest.fn(),
+  getPopularPosts: jest.fn(),
+  getRecentPosts: jest.fn(),
+  getPostById: jest.fn(),
+  incrementPostView: jest.fn(),
+  getPostReactions: jest.fn(),
+  createPost: jest.fn(),
+  updatePost: jest.fn(),
+  deletePost: jest.fn(),
+  updatePostReaction: jest.fn(),
+  reportPost: jest.fn(),
+  getComments: jest.fn(),
+  addComment: jest.fn(),
+  updateComment: jest.fn(),
+  deleteComment: jest.fn(),
+  reactToComment: jest.fn()
+}));
+
+const communityService = require('../../services/communityService');
+const communityController = require('../communityController');
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('communityController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns categories from the service', async () => {
+    communityService.getCategories.mockReturnValue([{ value: '자유' }]);
+    const req = {};
+    const res = createResponse();
+    const next = jest.fn();
+
+    await communityController.getCategories(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: [{ value: '자유' }]
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('delegates post retrieval to the service', async () => {
+    const post = { id: '1' };
+    communityService.getPostById.mockResolvedValue(post);
+    const req = { params: { id: '1' } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    await communityController.getPostById(req, res, next);
+
+    expect(communityService.getPostById).toHaveBeenCalledWith('1');
+    expect(res.json).toHaveBeenCalledWith({ success: true, data: post });
+  });
+
+  it('creates post and responds with status 201', async () => {
+    const created = { id: 'post-id' };
+    communityService.createPost.mockResolvedValue(created);
+    const req = { body: { title: 't' }, user: { _id: 'user' } };
+    const res = createResponse();
+    const next = jest.fn();
+
+    await communityController.createPost(req, res, next);
+
+    expect(communityService.createPost).toHaveBeenCalledWith({
+      title: 't',
+      author: 'user',
+      authorName: undefined
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      data: created,
+      message: '포스트가 생성되었습니다.'
+    });
+  });
+
+  it('passes errors to next middleware', async () => {
+    const error = new Error('boom');
+    communityService.getPosts.mockRejectedValue(error);
+    const req = { query: {} };
+    const res = createResponse();
+    const next = jest.fn();
+
+    await communityController.getPosts(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(error);
+  });
+});

--- a/server/src/controllers/communityController.js
+++ b/server/src/controllers/communityController.js
@@ -1,0 +1,188 @@
+const communityService = require('../services/communityService');
+
+const handleController = handler => async (req, res, next) => {
+  try {
+    await handler(req, res, next);
+  } catch (error) {
+    next(error);
+  }
+};
+
+const getTestStatus = handleController(async (_req, res) => {
+  res.json({
+    success: true,
+    message: '테스트 엔드포인트 작동 중',
+    timestamp: new Date().toISOString()
+  });
+});
+
+const getCategories = handleController(async (_req, res) => {
+  const categories = communityService.getCategories();
+  res.json({
+    success: true,
+    data: categories
+  });
+});
+
+const getPosts = handleController(async (req, res) => {
+  const { posts, pagination } = await communityService.getPosts(req.query);
+  res.json({
+    success: true,
+    posts,
+    pagination
+  });
+});
+
+const getPopularPosts = handleController(async (req, res) => {
+  const posts = await communityService.getPopularPosts(req.query);
+  res.json({
+    success: true,
+    data: posts
+  });
+});
+
+const getRecentPosts = handleController(async (req, res) => {
+  const posts = await communityService.getRecentPosts(req.query);
+  res.json({
+    success: true,
+    data: posts
+  });
+});
+
+const getPostById = handleController(async (req, res) => {
+  const post = await communityService.getPostById(req.params.id);
+  res.json({
+    success: true,
+    data: post
+  });
+});
+
+const incrementPostView = handleController(async (req, res) => {
+  const views = await communityService.incrementPostView(req.params.id);
+  res.json({
+    success: true,
+    message: '조회수가 증가되었습니다.',
+    data: { views }
+  });
+});
+
+const getPostReactions = handleController(async (req, res) => {
+  const data = await communityService.getPostReactions(req.params.id, req.user._id);
+  res.json({
+    success: true,
+    data
+  });
+});
+
+const createPost = handleController(async (req, res) => {
+  const post = await communityService.createPost({
+    ...req.body,
+    author: req.user._id,
+    authorName: req.body.authorName
+  });
+
+  res.status(201).json({
+    success: true,
+    data: post,
+    message: '포스트가 생성되었습니다.'
+  });
+});
+
+const updatePost = handleController(async (req, res) => {
+  const post = await communityService.updatePost(req.params.id, req.user, req.body);
+  res.json({
+    success: true,
+    data: post,
+    message: '포스트가 수정되었습니다.'
+  });
+});
+
+const deletePost = handleController(async (req, res) => {
+  await communityService.deletePost(req.params.id, req.user);
+  res.json({
+    success: true,
+    message: '포스트가 삭제되었습니다.'
+  });
+});
+
+const updatePostReaction = handleController(async (req, res) => {
+  const data = await communityService.updatePostReaction(req.params.id, req.user._id, req.body.reaction);
+  res.json({
+    success: true,
+    data,
+    message: '반응이 업데이트되었습니다.'
+  });
+});
+
+const reportPost = handleController(async (req, res) => {
+  await communityService.reportPost(req.params.id, req.user._id, req.body.reason);
+  res.json({
+    success: true,
+    message: '포스트가 신고되었습니다.'
+  });
+});
+
+const getComments = handleController(async (req, res) => {
+  const { comments, pagination } = await communityService.getComments(req.params.id, req.query);
+  res.json({
+    success: true,
+    data: comments,
+    pagination
+  });
+});
+
+const addComment = handleController(async (req, res) => {
+  const comment = await communityService.addComment(req.params.id, req.user, req.body);
+  res.status(201).json({
+    success: true,
+    message: '댓글이 작성되었습니다.',
+    data: comment
+  });
+});
+
+const updateComment = handleController(async (req, res) => {
+  const comment = await communityService.updateComment(req.params.id, req.params.commentId, req.user, req.body.content);
+  res.json({
+    success: true,
+    message: '댓글이 수정되었습니다.',
+    data: comment
+  });
+});
+
+const deleteComment = handleController(async (req, res) => {
+  await communityService.deleteComment(req.params.id, req.params.commentId, req.user);
+  res.json({
+    success: true,
+    message: '댓글이 삭제되었습니다.'
+  });
+});
+
+const reactToComment = handleController(async (req, res) => {
+  const data = await communityService.reactToComment(req.params.id, req.params.commentId, req.user._id, req.body.reaction);
+  res.json({
+    success: true,
+    message: '반응이 업데이트되었습니다.',
+    data
+  });
+});
+
+module.exports = {
+  getTestStatus,
+  getCategories,
+  getPosts,
+  getPopularPosts,
+  getRecentPosts,
+  getPostById,
+  incrementPostView,
+  getPostReactions,
+  createPost,
+  updatePost,
+  deletePost,
+  updatePostReaction,
+  reportPost,
+  getComments,
+  addComment,
+  updateComment,
+  deleteComment,
+  reactToComment
+};

--- a/server/src/repositories/__tests__/communityRepository.test.js
+++ b/server/src/repositories/__tests__/communityRepository.test.js
@@ -1,0 +1,86 @@
+const path = require('path');
+const communityPostPath = path.join(__dirname, '../../../models/CommunityPost');
+
+jest.mock(communityPostPath, () => {
+  const mockModel = jest.fn();
+  mockModel.find = jest.fn();
+  mockModel.countDocuments = jest.fn();
+  mockModel.findById = jest.fn();
+  return mockModel;
+});
+
+const CommunityPost = require(communityPostPath);
+const communityRepository = require('../communityRepository');
+
+const createQueryMock = () => ({
+  sort: jest.fn().mockReturnThis(),
+  skip: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  select: jest.fn().mockReturnThis(),
+  populate: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockReturnThis()
+});
+
+describe('communityRepository', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should query posts with population and pagination', async () => {
+    const queryMock = createQueryMock();
+    CommunityPost.find.mockReturnValue(queryMock);
+
+    const result = await communityRepository.findPosts({
+      query: { isActive: true },
+      sort: { createdAt: -1 },
+      skip: 20,
+      limit: 10
+    });
+
+    expect(CommunityPost.find).toHaveBeenCalledWith({ isActive: true });
+    expect(queryMock.sort).toHaveBeenCalledWith({ createdAt: -1 });
+    expect(queryMock.skip).toHaveBeenCalledWith(20);
+    expect(queryMock.limit).toHaveBeenCalledWith(10);
+    expect(queryMock.populate).toHaveBeenCalledWith('author', 'name role avatar');
+    expect(result).toBe(queryMock);
+  });
+
+  it('should populate post and comments when finding by id with comments', async () => {
+    const findByIdMock = createQueryMock();
+    CommunityPost.findById.mockReturnValue(findByIdMock);
+
+    const result = await communityRepository.findPostById('id', { includeComments: true });
+
+    expect(CommunityPost.findById).toHaveBeenCalledWith('id');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(1, 'author', 'name role avatar');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(2, 'comments.author', 'name role avatar');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(3, 'comments.replies.author', 'name role avatar');
+    expect(result).toBe(findByIdMock);
+  });
+
+  it('should create a post using the model constructor', async () => {
+    const saveMock = jest.fn().mockResolvedValue({ _id: '1' });
+    CommunityPost.mockImplementation(() => ({ save: saveMock }));
+
+    const payload = { title: 'test' };
+    const result = await communityRepository.createPost(payload);
+
+    expect(CommunityPost).toHaveBeenCalledWith(payload);
+    expect(saveMock).toHaveBeenCalled();
+    expect(result).toEqual({ _id: '1' });
+  });
+
+  it('should select comments when fetching comments by post id', async () => {
+    const findByIdMock = createQueryMock();
+    CommunityPost.findById.mockReturnValue(findByIdMock);
+
+    await communityRepository.findCommentsByPostId('id');
+
+    expect(CommunityPost.findById).toHaveBeenCalledWith('id');
+    expect(findByIdMock.select).toHaveBeenCalledWith('comments');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(1, 'author', 'name role avatar');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(2, 'comments.author', 'name role avatar');
+    expect(findByIdMock.populate).toHaveBeenNthCalledWith(3, 'comments.replies.author', 'name role avatar');
+    expect(findByIdMock.lean).toHaveBeenCalled();
+  });
+});

--- a/server/src/repositories/communityRepository.js
+++ b/server/src/repositories/communityRepository.js
@@ -1,0 +1,76 @@
+const CommunityPost = require('../../models/CommunityPost');
+
+const AUTHOR_FIELDS = 'name role avatar';
+
+const applyAuthorPopulation = (query, { includeComments = false } = {}) => {
+  let populatedQuery = query.populate('author', AUTHOR_FIELDS);
+
+  if (includeComments) {
+    populatedQuery = populatedQuery
+      .populate('comments.author', AUTHOR_FIELDS)
+      .populate('comments.replies.author', AUTHOR_FIELDS);
+  }
+
+  return populatedQuery;
+};
+
+const findPosts = async ({ query, sort, skip, limit }) => {
+  return applyAuthorPopulation(
+    CommunityPost.find(query).sort(sort).skip(skip).limit(limit),
+    { includeComments: false }
+  );
+};
+
+const countPosts = async query => {
+  return CommunityPost.countDocuments(query);
+};
+
+const findPopularPosts = async limit => {
+  return applyAuthorPopulation(
+    CommunityPost.find({ isActive: true }).sort({ likes: -1, viewCount: -1 }).limit(limit),
+    { includeComments: false }
+  );
+};
+
+const findRecentPosts = async limit => {
+  return applyAuthorPopulation(
+    CommunityPost.find({ isActive: true }).sort({ createdAt: -1 }).limit(limit),
+    { includeComments: false }
+  );
+};
+
+const findPostById = async (id, { includeComments = false } = {}) => {
+  return applyAuthorPopulation(CommunityPost.findById(id), { includeComments });
+};
+
+const findPostDocumentById = async id => {
+  return CommunityPost.findById(id);
+};
+
+const createPost = async data => {
+  const post = new CommunityPost(data);
+  return post.save();
+};
+
+const savePost = async post => {
+  return post.save();
+};
+
+const findCommentsByPostId = async id => {
+  return applyAuthorPopulation(
+    CommunityPost.findById(id).select('comments'),
+    { includeComments: true }
+  ).lean();
+};
+
+module.exports = {
+  findPosts,
+  countPosts,
+  findPopularPosts,
+  findRecentPosts,
+  findPostById,
+  findPostDocumentById,
+  createPost,
+  savePost,
+  findCommentsByPostId
+};

--- a/server/src/services/__tests__/communityService.test.js
+++ b/server/src/services/__tests__/communityService.test.js
@@ -1,0 +1,124 @@
+jest.mock('../../repositories/communityRepository', () => ({
+  findPosts: jest.fn(),
+  countPosts: jest.fn(),
+  findPopularPosts: jest.fn(),
+  findRecentPosts: jest.fn(),
+  findPostById: jest.fn(),
+  findPostDocumentById: jest.fn(),
+  createPost: jest.fn(),
+  savePost: jest.fn(),
+  findCommentsByPostId: jest.fn()
+}));
+
+const communityRepository = require('../../repositories/communityRepository');
+const communityService = require('../communityService');
+const { ValidationError } = require('../../errors/AppError');
+
+describe('communityService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getPosts', () => {
+    it('builds query options and returns posts with pagination', async () => {
+      const posts = [{ id: 1 }];
+      communityRepository.findPosts.mockResolvedValue(posts);
+      communityRepository.countPosts.mockResolvedValue(25);
+
+      const result = await communityService.getPosts({
+        page: 2,
+        limit: 5,
+        search: '테스트',
+        category: '자유',
+        sortBy: 'popular'
+      });
+
+      expect(communityRepository.findPosts).toHaveBeenCalledTimes(1);
+      const callArgs = communityRepository.findPosts.mock.calls[0][0];
+      expect(callArgs.query.isActive).toBe(true);
+      expect(callArgs.query.category).toBe('자유');
+      expect(callArgs.query.$or).toHaveLength(3);
+      expect(callArgs.sort).toEqual({ likes: -1, viewCount: -1 });
+      expect(callArgs.skip).toBe(5);
+      expect(callArgs.limit).toBe(5);
+
+      expect(result).toEqual({
+        posts,
+        pagination: {
+          page: 2,
+          limit: 5,
+          total: 25,
+          pages: 5
+        }
+      });
+    });
+  });
+
+  describe('getPostById', () => {
+    it('increments view count and returns post', async () => {
+      const post = { isActive: true, viewCount: 3 };
+      communityRepository.findPostById.mockResolvedValue(post);
+      communityRepository.savePost.mockResolvedValue();
+
+      const result = await communityService.getPostById('abc');
+
+      expect(post.viewCount).toBe(4);
+      expect(communityRepository.savePost).toHaveBeenCalledWith(post);
+      expect(result).toBe(post);
+    });
+  });
+
+  describe('createPost', () => {
+    it('creates post with default author name when missing', async () => {
+      communityRepository.createPost.mockResolvedValue({ _id: 'new-id' });
+      communityRepository.findPostById.mockResolvedValue({ _id: 'new-id', title: 'post' });
+
+      await communityService.createPost({
+        title: 'title',
+        content: 'content',
+        category: '자유',
+        author: 'user-id'
+      });
+
+      expect(communityRepository.createPost).toHaveBeenCalledWith({
+        title: 'title',
+        content: 'content',
+        category: '자유',
+        tags: [],
+        images: [],
+        author: 'user-id',
+        authorName: '사용자'
+      });
+    });
+  });
+
+  describe('updatePostReaction', () => {
+    it('toggles like reaction and updates counts', async () => {
+      const post = {
+        isActive: true,
+        likes: [],
+        dislikes: []
+      };
+      communityRepository.findPostDocumentById.mockResolvedValue(post);
+      communityRepository.savePost.mockResolvedValue();
+
+      const result = await communityService.updatePostReaction('post-id', 'user-id', 'like');
+
+      expect(post.likes).toContain('user-id');
+      expect(post.dislikes).toHaveLength(0);
+      expect(communityRepository.savePost).toHaveBeenCalledWith(post);
+      expect(result).toEqual({
+        likes: 1,
+        dislikes: 0,
+        isLiked: true,
+        isDisliked: false
+      });
+    });
+
+    it('throws validation error when reaction is invalid', async () => {
+      await expect(
+        communityService.updatePostReaction('post', 'user', 'invalid')
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+});

--- a/server/src/services/communityService.js
+++ b/server/src/services/communityService.js
@@ -1,0 +1,487 @@
+const {
+  ValidationError,
+  NotFoundError,
+  AuthorizationError
+} = require('../errors/AppError');
+const communityRepository = require('../repositories/communityRepository');
+
+const DEFAULT_CATEGORIES = [
+  { value: '자유', label: '자유', color: 'bg-blue-100 text-blue-700' },
+  { value: '질문', label: '질문', color: 'bg-yellow-100 text-yellow-700' },
+  { value: '음악', label: '음악', color: 'bg-purple-100 text-purple-700' },
+  { value: '미술', label: '미술', color: 'bg-pink-100 text-pink-700' },
+  { value: '문학', label: '문학', color: 'bg-green-100 text-green-700' },
+  { value: '공연', label: '공연', color: 'bg-orange-100 text-orange-700' },
+  { value: '사진', label: '사진', color: 'bg-indigo-100 text-indigo-700' },
+  { value: '기술', label: '기술', color: 'bg-cyan-100 text-cyan-700' },
+  { value: '기타', label: '기타', color: 'bg-gray-100 text-gray-700' }
+];
+
+const parsePositiveInt = (value, defaultValue) => {
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return parsed;
+};
+
+const ensureActivePost = (post, notFoundMessage = '포스트를 찾을 수 없습니다.') => {
+  if (!post || !post.isActive) {
+    throw new NotFoundError(notFoundMessage);
+  }
+};
+
+const getCategories = () => DEFAULT_CATEGORIES;
+
+const getPosts = async ({ page = 1, limit = 20, search = '', category = '', sortBy = 'latest' }) => {
+  const parsedPage = parsePositiveInt(page, 1);
+  const parsedLimit = parsePositiveInt(limit, 20);
+
+  const query = { isActive: true };
+
+  if (search) {
+    query.$or = [
+      { title: { $regex: search, $options: 'i' } },
+      { content: { $regex: search, $options: 'i' } },
+      { tags: { $in: [new RegExp(search, 'i')] } }
+    ];
+  }
+
+  if (category && category !== 'all') {
+    query.category = category;
+  }
+
+  const skip = (parsedPage - 1) * parsedLimit;
+
+  let sortQuery = { createdAt: -1 };
+  switch (sortBy) {
+    case 'popular':
+      sortQuery = { likes: -1, viewCount: -1 };
+      break;
+    case 'oldest':
+      sortQuery = { createdAt: 1 };
+      break;
+    case 'latest':
+    default:
+      sortQuery = { createdAt: -1 };
+      break;
+  }
+
+  const [posts, total] = await Promise.all([
+    communityRepository.findPosts({ query, sort: sortQuery, skip, limit: parsedLimit }),
+    communityRepository.countPosts(query)
+  ]);
+
+  return {
+    posts,
+    pagination: {
+      page: parsedPage,
+      limit: parsedLimit,
+      total,
+      pages: Math.ceil(total / parsedLimit)
+    }
+  };
+};
+
+const getPopularPosts = async ({ limit = 10 }) => {
+  const parsedLimit = parsePositiveInt(limit, 10);
+  return communityRepository.findPopularPosts(parsedLimit);
+};
+
+const getRecentPosts = async ({ limit = 10 }) => {
+  const parsedLimit = parsePositiveInt(limit, 10);
+  return communityRepository.findRecentPosts(parsedLimit);
+};
+
+const getPostById = async id => {
+  const post = await communityRepository.findPostById(id, { includeComments: true });
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  post.viewCount += 1;
+  await communityRepository.savePost(post);
+
+  return post;
+};
+
+const incrementPostView = async id => {
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  post.viewCount += 1;
+  await communityRepository.savePost(post);
+
+  return post.viewCount;
+};
+
+const getPostReactions = async (id, userId) => {
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  const userIdString = userId.toString();
+  const isLiked = post.likes.some(like => like.toString() === userIdString);
+  const isDisliked = post.dislikes.some(dislike => dislike.toString() === userIdString);
+
+  return {
+    isLiked,
+    isDisliked,
+    likes: post.likes.length,
+    dislikes: post.dislikes.length
+  };
+};
+
+const createPost = async ({ title, content, category, tags = [], images = [], author, authorName }) => {
+  if (!title || !content || !category) {
+    throw new ValidationError('제목, 내용, 카테고리는 필수입니다.');
+  }
+
+  const createdPost = await communityRepository.createPost({
+    title,
+    content,
+    category,
+    tags,
+    images,
+    author,
+    authorName: authorName || '사용자'
+  });
+
+  return communityRepository.findPostById(createdPost._id, { includeComments: false });
+};
+
+const updatePost = async (id, user, { title, content, category, tags }) => {
+  const post = await communityRepository.findPostDocumentById(id);
+  if (!post) {
+    throw new NotFoundError('포스트를 찾을 수 없습니다.');
+  }
+
+  if (post.author.toString() !== user._id && user.role !== 'admin') {
+    throw new AuthorizationError('포스트를 수정할 권한이 없습니다.');
+  }
+
+  post.title = title || post.title;
+  post.content = content || post.content;
+  post.category = category || post.category;
+  post.tags = tags || post.tags;
+  post.updatedAt = new Date();
+
+  await communityRepository.savePost(post);
+
+  return communityRepository.findPostById(id, { includeComments: false });
+};
+
+const deletePost = async (id, user) => {
+  const post = await communityRepository.findPostDocumentById(id);
+  if (!post) {
+    throw new NotFoundError('포스트를 찾을 수 없습니다.');
+  }
+
+  if (post.author.toString() !== user._id && user.role !== 'admin') {
+    throw new AuthorizationError('포스트를 삭제할 권한이 없습니다.');
+  }
+
+  post.isActive = false;
+  post.deletedAt = new Date();
+
+  await communityRepository.savePost(post);
+};
+
+const updatePostReaction = async (id, userId, reaction) => {
+  if (!['like', 'dislike', 'unlike', 'undislike'].includes(reaction)) {
+    throw new ValidationError('유효하지 않은 반응 타입입니다.');
+  }
+
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  const userIdString = userId.toString();
+  const isLiked = post.likes.some(like => like.toString() === userIdString);
+  const isDisliked = post.dislikes.some(dislike => dislike.toString() === userIdString);
+
+  if (reaction === 'like') {
+    if (isLiked) {
+      post.likes = post.likes.filter(like => like.toString() !== userIdString);
+    } else {
+      post.likes.push(userId);
+      post.dislikes = post.dislikes.filter(dislike => dislike.toString() !== userIdString);
+    }
+  } else if (reaction === 'dislike') {
+    if (isDisliked) {
+      post.dislikes = post.dislikes.filter(dislike => dislike.toString() !== userIdString);
+    } else {
+      post.dislikes.push(userId);
+      post.likes = post.likes.filter(like => like.toString() !== userIdString);
+    }
+  } else if (reaction === 'unlike') {
+    post.likes = post.likes.filter(like => like.toString() !== userIdString);
+  } else if (reaction === 'undislike') {
+    post.dislikes = post.dislikes.filter(dislike => dislike.toString() !== userIdString);
+  }
+
+  await communityRepository.savePost(post);
+
+  return {
+    likes: post.likes.length,
+    dislikes: post.dislikes.length,
+    isLiked: post.likes.some(like => like.toString() === userIdString),
+    isDisliked: post.dislikes.some(dislike => dislike.toString() === userIdString)
+  };
+};
+
+const reportPost = async (id, userId, reason) => {
+  if (!reason) {
+    throw new ValidationError('신고 사유를 입력해주세요.');
+  }
+
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  const alreadyReported = post.reports.some(report => report.reporter.toString() === userId.toString());
+  if (alreadyReported) {
+    throw new ValidationError('이미 신고한 포스트입니다.');
+  }
+
+  post.reports.push({
+    reporter: userId,
+    reason,
+    reportedAt: new Date()
+  });
+
+  if (post.reports.length >= 5) {
+    post.isActive = false;
+    post.isReported = true;
+  }
+
+  await communityRepository.savePost(post);
+};
+
+const getComments = async (id, { page = 1, limit = 20, sortBy = 'createdAt', order = 'desc' }) => {
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  const parsedPage = parsePositiveInt(page, 1);
+  const parsedLimit = parsePositiveInt(limit, 20);
+
+  const commentsDocument = await communityRepository.findCommentsByPostId(id);
+
+  if (!commentsDocument) {
+    return {
+      comments: [],
+      pagination: {
+        page: parsedPage,
+        limit: parsedLimit,
+        total: 0,
+        pages: 0
+      }
+    };
+  }
+
+  const sortOrder = order === 'desc' ? -1 : 1;
+  const sortedComments = [...commentsDocument.comments].sort((a, b) => {
+    if (sortBy === 'createdAt') {
+      return sortOrder === -1
+        ? new Date(b.createdAt) - new Date(a.createdAt)
+        : new Date(a.createdAt) - new Date(b.createdAt);
+    }
+
+    return 0;
+  });
+
+  const skip = (parsedPage - 1) * parsedLimit;
+  const paginatedComments = sortedComments.slice(skip, skip + parsedLimit);
+
+  return {
+    comments: paginatedComments,
+    pagination: {
+      page: parsedPage,
+      limit: parsedLimit,
+      total: commentsDocument.comments.length,
+      pages: Math.ceil(commentsDocument.comments.length / parsedLimit)
+    }
+  };
+};
+
+const addComment = async (id, user, { content, parentId }) => {
+  if (!content || content.trim().length === 0) {
+    throw new ValidationError('댓글 내용을 입력해주세요.');
+  }
+
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  const newComment = {
+    author: user._id,
+    authorName: user.name || '사용자',
+    content: content.trim(),
+    parentId: parentId || null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    likes: [],
+    dislikes: [],
+    replies: []
+  };
+
+  if (parentId) {
+    const parentComment = post.comments.id(parentId);
+    if (!parentComment) {
+      throw new NotFoundError('상위 댓글을 찾을 수 없습니다.');
+    }
+    parentComment.replies.push(newComment);
+  } else {
+    post.comments.push(newComment);
+  }
+
+  await communityRepository.savePost(post);
+
+  const populatedPost = await communityRepository.findPostById(id, { includeComments: true });
+
+  if (parentId) {
+    const parent = populatedPost.comments.id(parentId);
+    return parent.replies[parent.replies.length - 1];
+  }
+
+  return populatedPost.comments[populatedPost.comments.length - 1];
+};
+
+const updateComment = async (id, commentId, user, content) => {
+  if (!content || content.trim().length === 0) {
+    throw new ValidationError('댓글 내용을 입력해주세요.');
+  }
+
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  let comment = post.comments.id(commentId);
+  let parentComment = null;
+
+  if (!comment) {
+    for (const current of post.comments) {
+      const reply = current.replies.id(commentId);
+      if (reply) {
+        comment = reply;
+        parentComment = current;
+        break;
+      }
+    }
+  }
+
+  if (!comment) {
+    throw new NotFoundError('댓글을 찾을 수 없습니다.');
+  }
+
+  if (comment.author.toString() !== user._id && user.role !== 'admin') {
+    throw new AuthorizationError('댓글을 수정할 권한이 없습니다.');
+  }
+
+  comment.content = content.trim();
+  comment.updatedAt = new Date();
+
+  await communityRepository.savePost(post);
+
+  return parentComment ? parentComment.replies.id(commentId) : post.comments.id(commentId);
+};
+
+const deleteComment = async (id, commentId, user) => {
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  let comment = post.comments.id(commentId);
+  let parentComment = null;
+
+  if (!comment) {
+    for (const current of post.comments) {
+      const reply = current.replies.id(commentId);
+      if (reply) {
+        comment = reply;
+        parentComment = current;
+        break;
+      }
+    }
+  }
+
+  if (!comment) {
+    throw new NotFoundError('댓글을 찾을 수 없습니다.');
+  }
+
+  if (comment.author.toString() !== user._id && user.role !== 'admin') {
+    throw new AuthorizationError('댓글을 삭제할 권한이 없습니다.');
+  }
+
+  if (parentComment) {
+    parentComment.replies.pull(commentId);
+  } else {
+    post.comments.pull(commentId);
+  }
+
+  await communityRepository.savePost(post);
+};
+
+const reactToComment = async (id, commentId, userId, reaction) => {
+  if (!['like', 'dislike', 'unlike'].includes(reaction)) {
+    throw new ValidationError('유효하지 않은 반응 타입입니다.');
+  }
+
+  const post = await communityRepository.findPostDocumentById(id);
+  ensureActivePost(post, '포스트를 찾을 수 없습니다.');
+
+  let comment = post.comments.id(commentId);
+  if (!comment) {
+    for (const current of post.comments) {
+      const reply = current.replies.id(commentId);
+      if (reply) {
+        comment = reply;
+        break;
+      }
+    }
+  }
+
+  if (!comment) {
+    throw new NotFoundError('댓글을 찾을 수 없습니다.');
+  }
+
+  const userIdString = userId.toString();
+
+  if (reaction === 'like') {
+    if (comment.likes.some(like => like.toString() === userIdString)) {
+      comment.likes.pull(userId);
+    } else {
+      comment.likes.push(userId);
+      comment.dislikes.pull(userId);
+    }
+  } else if (reaction === 'dislike') {
+    if (comment.dislikes.some(dislike => dislike.toString() === userIdString)) {
+      comment.dislikes.pull(userId);
+    } else {
+      comment.dislikes.push(userId);
+      comment.likes.pull(userId);
+    }
+  } else if (reaction === 'unlike') {
+    comment.likes.pull(userId);
+    comment.dislikes.pull(userId);
+  }
+
+  await communityRepository.savePost(post);
+
+  return {
+    likes: comment.likes.length,
+    dislikes: comment.dislikes.length
+  };
+};
+
+module.exports = {
+  getCategories,
+  getPosts,
+  getPopularPosts,
+  getRecentPosts,
+  getPostById,
+  incrementPostView,
+  getPostReactions,
+  createPost,
+  updatePost,
+  deletePost,
+  updatePostReaction,
+  reportPost,
+  getComments,
+  addComment,
+  updateComment,
+  deleteComment,
+  reactToComment
+};


### PR DESCRIPTION
## Summary
- move community route responsibilities into dedicated controller, service, and repository layers
- add focused unit tests covering controller, service, and repository behaviours
- update community routes to perform validation before delegating to the controller and make Jest setup resilient when optional tooling is unavailable

## Testing
- npx jest src/controllers/__tests__/communityController.test.js src/services/__tests__/communityService.test.js src/repositories/__tests__/communityRepository.test.js --runInBand


------
https://chatgpt.com/codex/tasks/task_b_68cdf171ebd883269478a6b2b5c86bc4