### PR TITLE
feat: connect community admin and fan pages to APIs

### DIFF
--- a/src/components/AdminDashboardSystem.tsx
+++ b/src/components/AdminDashboardSystem.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader } from "@/shared/ui/Card";
 import { Button } from "@/shared/ui/Button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/shared/ui/Tabs";
+import { ErrorMessage, ProjectListSkeleton } from "@/shared/ui";
 import {
   Users,
   DollarSign,
   AlertTriangle,
   BarChart3,
-  Settings,
   Shield,
   Eye,
   Edit,
@@ -15,11 +16,32 @@ import {
   XCircle,
   Clock
 } from "lucide-react";
+import { statsAPI, adminAPI } from "@/services/api";
+import { adminService } from "@/features/admin/services/adminService";
+import { formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
 
 interface AdminDashboardSystemProps {
   onUserAction?: (action: string, userId: string) => void;
   onProjectAction?: (action: string, projectId: string) => void;
 }
+
+const safeNumber = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const fallbackId = () => Math.random().toString(36).slice(2, 10);
+
+const formatRelativeTime = (value?: string) => {
+  if (!value) return "";
+
+  try {
+    return formatDistanceToNow(new Date(value), { addSuffix: true, locale: ko });
+  } catch (error) {
+    return value;
+  }
+};
 
 const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
   onUserAction,
@@ -27,123 +49,218 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
 }) => {
   const [activeTab, setActiveTab] = useState("overview");
 
-  // 임시 데이터
-  const mockStats = {
-    totalUsers: 1250,
-    totalProjects: 89,
-    totalRevenue: 12500000,
-    pendingApprovals: 12,
-    activeUsers: 890,
-    completedProjects: 67,
-    monthlyGrowth: 15.2,
-    systemHealth: 98.5
-  };
+  const {
+    data: platformStatsData,
+    isLoading: platformStatsLoading,
+    error: platformStatsError,
+    refetch: refetchPlatformStats,
+  } = useQuery({
+    queryKey: ["stats", "platform"],
+    queryFn: statsAPI.getPlatformStats,
+    staleTime: 5 * 60 * 1000,
+  });
 
-  const mockUsers = [
-    {
-      id: "1",
-      name: "김아티스트",
-      email: "artist@example.com",
-      role: "artist",
-      status: "active",
-      joinDate: "2024-01-15",
-      projects: 3,
-      lastActive: "2024-02-10"
-    },
-    {
-      id: "2",
-      name: "박팬",
-      email: "fan@example.com",
-      role: "fan",
-      status: "active",
-      joinDate: "2024-01-20",
-      projects: 0,
-      lastActive: "2024-02-09"
+  const {
+    data: dashboardMetricsData,
+    isLoading: dashboardMetricsLoading,
+    error: dashboardMetricsError,
+    refetch: refetchDashboardMetrics,
+  } = useQuery({
+    queryKey: ["admin", "dashboard", "metrics"],
+    queryFn: adminService.getDashboardMetrics,
+    staleTime: 2 * 60 * 1000,
+    refetchInterval: 30 * 1000,
+  });
+
+  const {
+    data: usersData,
+    isLoading: usersLoading,
+    error: usersError,
+    refetch: refetchUsers,
+  } = useQuery({
+    queryKey: ["admin", "users", "recent"],
+    queryFn: () => adminService.getUsers({ limit: 5, sortBy: "createdAt", order: "desc" }),
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const {
+    data: projectsData,
+    isLoading: projectsLoading,
+    error: projectsError,
+    refetch: refetchProjects,
+  } = useQuery({
+    queryKey: ["admin", "funding", "projects", "recent"],
+    queryFn: () => adminService.getFundingProjects({ limit: 5, sortBy: "createdAt", order: "desc" }),
+    staleTime: 2 * 60 * 1000,
+  });
+
+  const {
+    data: notificationsData,
+    isLoading: alertsLoading,
+    error: alertsError,
+    refetch: refetchAlerts,
+  } = useQuery({
+    queryKey: ["admin", "notifications"],
+    queryFn: adminService.getNotifications,
+    staleTime: 30 * 1000,
+    refetchInterval: 30 * 1000,
+  });
+
+  const { data: reportedContentData } = useQuery({
+    queryKey: ["admin", "reported-content"],
+    queryFn: adminAPI.getReportedContent,
+    staleTime: 60 * 1000,
+  });
+
+  const platformStats = useMemo(() => ((platformStatsData as any)?.data ?? platformStatsData ?? {}), [platformStatsData]);
+  const dashboardMetrics = useMemo(() => ((dashboardMetricsData as any)?.data ?? dashboardMetricsData ?? {}), [dashboardMetricsData]);
+
+  const pendingReportsCount = useMemo(() => {
+    const raw = (reportedContentData as any)?.data ?? reportedContentData ?? [];
+
+    if (Array.isArray(raw)) {
+      return raw.length;
     }
-  ];
 
-  const mockProjects = [
-    {
-      id: "1",
-      title: "새로운 앨범 프로젝트",
-      artist: "김아티스트",
-      status: "collecting",
-      amount: 7500000,
-      targetAmount: 10000000,
-      backers: 156,
-      createdAt: "2024-01-15"
-    },
-    {
-      id: "2",
-      title: "콘서트 개최 프로젝트",
-      artist: "박뮤지션",
-      status: "succeeded",
-      amount: 5000000,
-      targetAmount: 5000000,
-      backers: 89,
-      createdAt: "2024-01-10"
+    if (Array.isArray(raw?.items)) {
+      return raw.items.length;
     }
-  ];
 
-  const mockAlerts = [
-    {
-      id: "1",
-      type: "warning",
-      title: "시스템 리소스 사용량 높음",
-      message: "CPU 사용률이 85%를 초과했습니다.",
-      time: "5분 전"
-    },
-    {
-      id: "2",
-      type: "info",
-      title: "새로운 프로젝트 승인 요청",
-      message: "3개의 프로젝트가 승인을 기다리고 있습니다.",
-      time: "1시간 전"
+    if (typeof raw?.total === "number") {
+      return raw.total;
     }
-  ];
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('ko-KR', {
-      style: 'currency',
-      currency: 'KRW',
+    return 0;
+  }, [reportedContentData]);
+
+  const computedStats = useMemo(() => {
+    const totalUsers = safeNumber(platformStats.totalUsers ?? dashboardMetrics.userMetrics?.totalUsers);
+    const totalProjects = safeNumber(platformStats.totalProjects ?? dashboardMetrics.fundingMetrics?.activeProjects);
+    const totalRevenue = safeNumber(
+      platformStats.totalFunding ?? platformStats.totalRevenue ?? dashboardMetrics.revenueMetrics?.monthlyRevenue
+    );
+    const activeUsers = safeNumber(
+      platformStats.activeUsers ?? dashboardMetrics.userMetrics?.activeArtists ?? dashboardMetrics.userMetrics?.newUsersThisWeek
+    );
+    const completedProjects = safeNumber(dashboardMetrics.fundingMetrics?.successfulProjectsThisMonth);
+    const pendingApprovals = safeNumber(dashboardMetrics.communityMetrics?.pendingReports ?? pendingReportsCount);
+    const monthlyGrowth = safeNumber(dashboardMetrics.revenueMetrics?.growthRate);
+    const queueSize = safeNumber(dashboardMetrics.communityMetrics?.moderationQueue ?? pendingReportsCount);
+    const systemHealth = Math.max(55, Math.min(100, 100 - queueSize * 2));
+
+    return {
+      totalUsers,
+      totalProjects,
+      totalRevenue,
+      pendingApprovals,
+      activeUsers,
+      completedProjects,
+      monthlyGrowth,
+      systemHealth,
+    };
+  }, [dashboardMetrics, pendingReportsCount, platformStats]);
+
+  const users = useMemo(() => {
+    if (!usersData) return [];
+    const raw = (usersData as any).data?.users ?? (usersData as any).users ?? (Array.isArray(usersData) ? usersData : []);
+    return Array.isArray(raw) ? raw : [];
+  }, [usersData]);
+
+  const normalizedUsers = useMemo(() => {
+    return users.map((user: any) => ({
+      id: String(user.id ?? user._id ?? user.userId ?? user.uuid ?? fallbackId()),
+      name: user.name ?? user.username ?? "이름 미상",
+      email: user.email ?? "이메일 정보 없음",
+      status: (user.status ?? "active") as string,
+      joinDate: user.joinDate ?? user.createdAt ?? "",
+      lastActive: user.lastActivity ?? user.lastLogin ?? user.updatedAt ?? "",
+      projects: safeNumber(user.fundingCount ?? user.projectCount ?? user.projects ?? 0),
+    }));
+  }, [users]);
+
+  const projects = useMemo(() => {
+    if (!projectsData) return [];
+    const raw = (projectsData as any).data ?? (projectsData as any).projects ?? (Array.isArray(projectsData) ? projectsData : []);
+    return Array.isArray(raw) ? raw : [];
+  }, [projectsData]);
+
+  const normalizedProjects = useMemo(() => {
+    return projects.map((project: any) => ({
+      id: String(project.id ?? project._id ?? project.projectId ?? fallbackId()),
+      title: project.title ?? "이름 없는 프로젝트",
+      artist: project.artist?.name ?? project.artistName ?? "알 수 없음",
+      status: (project.approvalStatus ?? project.status ?? "pending") as string,
+      amount: safeNumber(project.currentAmount ?? project.amount ?? project.raisedAmount ?? 0),
+      targetAmount: safeNumber(project.goalAmount ?? project.targetAmount ?? project.fundingGoal ?? 0),
+      backers: safeNumber(project.backerCount ?? project.backers ?? 0),
+      createdAt: project.submissionDate ?? project.createdAt ?? "",
+    }));
+  }, [projects]);
+
+  const alerts = useMemo(() => {
+    const raw = (notificationsData as any)?.data ?? notificationsData ?? [];
+    return Array.isArray(raw) ? raw : [];
+  }, [notificationsData]);
+
+  const statsLoading = platformStatsLoading || dashboardMetricsLoading;
+  const statsError = platformStatsError || dashboardMetricsError;
+
+  const formatCurrency = (amount: unknown) => {
+    return new Intl.NumberFormat("ko-KR", {
+      style: "currency",
+      currency: "KRW",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
-    }).format(amount);
+    }).format(safeNumber(amount));
   };
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'active':
-        return 'bg-success-100 text-success-700';
-      case 'inactive':
-        return 'bg-gray-100 text-gray-700';
-      case 'suspended':
-        return 'bg-danger-100 text-danger-700';
-      case 'collecting':
-        return 'bg-primary-100 text-primary-700';
-      case 'succeeded':
-        return 'bg-success-100 text-success-700';
-      case 'failed':
-        return 'bg-danger-100 text-danger-700';
+      case "active":
+      case "approved":
+        return "bg-success-100 text-success-700";
+      case "inactive":
+        return "bg-gray-100 text-gray-700";
+      case "suspended":
+      case "banned":
+      case "rejected":
+        return "bg-danger-100 text-danger-700";
+      case "collecting":
+      case "pending":
+      case "under_review":
+        return "bg-warning-100 text-warning-700";
+      case "succeeded":
+        return "bg-success-100 text-success-700";
+      case "failed":
+        return "bg-danger-100 text-danger-700";
       default:
-        return 'bg-gray-100 text-gray-700';
+        return "bg-gray-100 text-gray-700";
     }
   };
 
   const getStatusText = (status: string) => {
     switch (status) {
-      case 'active':
-        return '활성';
-      case 'inactive':
-        return '비활성';
-      case 'suspended':
-        return '정지';
-      case 'collecting':
-        return '모금 중';
-      case 'succeeded':
-        return '성공';
-      case 'failed':
-        return '실패';
+      case "active":
+        return "활성";
+      case "inactive":
+        return "비활성";
+      case "suspended":
+      case "banned":
+        return "정지";
+      case "collecting":
+        return "모금 중";
+      case "succeeded":
+        return "성공";
+      case "failed":
+        return "실패";
+      case "pending":
+        return "대기";
+      case "approved":
+        return "승인";
+      case "under_review":
+        return "검토 중";
+      case "rejected":
+        return "거절";
       default:
         return status;
     }
@@ -151,11 +268,12 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
 
   const getAlertIcon = (type: string) => {
     switch (type) {
-      case 'warning':
+      case "warning":
         return <AlertTriangle className="w-5 h-5 text-warning-600" />;
-      case 'error':
+      case "error":
+      case "urgent":
         return <XCircle className="w-5 h-5 text-danger-600" />;
-      case 'success':
+      case "success":
         return <CheckCircle className="w-5 h-5 text-success-600" />;
       default:
         return <Clock className="w-5 h-5 text-blue-600" />;
@@ -171,6 +289,18 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
           <p className="text-gray-600 mt-1">시스템 전체 현황을 모니터링하고 관리하세요</p>
         </div>
 
+        {statsError && (
+          <div className="mb-6">
+            <ErrorMessage
+              error={statsError as Error}
+              onRetry={() => {
+                refetchPlatformStats();
+                refetchDashboardMetrics();
+              }}
+            />
+          </div>
+        )}
+
         {/* 통계 카드 */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
           <Card>
@@ -179,7 +309,9 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <Users className="w-8 h-8 text-blue-600" />
                 <div>
                   <p className="text-sm text-gray-600">총 사용자</p>
-                  <p className="text-2xl font-bold text-gray-900">{mockStats.totalUsers.toLocaleString()}</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {statsLoading ? "..." : computedStats.totalUsers.toLocaleString()}
+                  </p>
                 </div>
               </div>
             </CardContent>
@@ -191,7 +323,9 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <DollarSign className="w-8 h-8 text-green-600" />
                 <div>
                   <p className="text-sm text-gray-600">총 수익</p>
-                  <p className="text-2xl font-bold text-gray-900">{formatCurrency(mockStats.totalRevenue)}</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {statsLoading ? "..." : formatCurrency(computedStats.totalRevenue)}
+                  </p>
                 </div>
               </div>
             </CardContent>
@@ -203,7 +337,9 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <BarChart3 className="w-8 h-8 text-purple-600" />
                 <div>
                   <p className="text-sm text-gray-600">총 프로젝트</p>
-                  <p className="text-2xl font-bold text-gray-900">{mockStats.totalProjects}</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {statsLoading ? "..." : computedStats.totalProjects.toLocaleString()}
+                  </p>
                 </div>
               </div>
             </CardContent>
@@ -215,7 +351,9 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <AlertTriangle className="w-8 h-8 text-warning-600" />
                 <div>
                   <p className="text-sm text-gray-600">승인 대기</p>
-                  <p className="text-2xl font-bold text-gray-900">{mockStats.pendingApprovals}</p>
+                  <p className="text-2xl font-bold text-gray-900">
+                    {statsLoading ? "..." : computedStats.pendingApprovals.toLocaleString()}
+                  </p>
                 </div>
               </div>
             </CardContent>
@@ -223,27 +361,33 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
         </div>
 
         {/* 알림 */}
-        {mockAlerts.length > 0 && (
-          <Card className="mb-8">
-            <CardHeader>
-              <h3 className="text-lg font-semibold">시스템 알림</h3>
-            </CardHeader>
-            <CardContent>
+        <Card className="mb-8">
+          <CardHeader>
+            <h3 className="text-lg font-semibold">시스템 알림</h3>
+          </CardHeader>
+          <CardContent>
+            {alertsLoading ? (
+              <ProjectListSkeleton />
+            ) : alertsError ? (
+              <ErrorMessage error={alertsError as Error} onRetry={() => refetchAlerts()} />
+            ) : alerts.length > 0 ? (
               <div className="space-y-3">
-                {mockAlerts.map((alert) => (
+                {alerts.map((alert: any) => (
                   <div key={alert.id} className="flex items-center space-x-3 p-3 bg-gray-50 rounded-lg">
                     {getAlertIcon(alert.type)}
                     <div className="flex-1">
                       <p className="font-medium text-gray-900">{alert.title}</p>
                       <p className="text-sm text-gray-600">{alert.message}</p>
                     </div>
-                    <span className="text-xs text-gray-500">{alert.time}</span>
+                    <span className="text-xs text-gray-500">{formatRelativeTime(alert.timestamp)}</span>
                   </div>
                 ))}
               </div>
-            </CardContent>
-          </Card>
-        )}
+            ) : (
+              <p className="text-sm text-gray-500">새로운 시스템 알림이 없습니다.</p>
+            )}
+          </CardContent>
+        </Card>
 
         {/* 탭 컨텐츠 */}
         <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -265,25 +409,35 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                   <div className="space-y-4">
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-gray-600">시스템 건강도</span>
-                      <span className="font-semibold text-green-600">{mockStats.systemHealth}%</span>
+                      <span className="font-semibold text-green-600">
+                        {statsLoading ? "..." : `${computedStats.systemHealth}%`}
+                      </span>
                     </div>
                     <div className="w-full bg-gray-200 rounded-full h-2">
                       <div
                         className="bg-green-500 h-2 rounded-full"
-                        style={{ width: `${mockStats.systemHealth}%` }}
+                        style={{ width: `${statsLoading ? 0 : computedStats.systemHealth}%` }}
                       />
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-gray-600">활성 사용자</span>
-                      <span className="font-semibold">{mockStats.activeUsers}</span>
+                      <span className="font-semibold">
+                        {statsLoading ? "..." : computedStats.activeUsers.toLocaleString()}
+                      </span>
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-gray-600">완료된 프로젝트</span>
-                      <span className="font-semibold">{mockStats.completedProjects}</span>
+                      <span className="font-semibold">
+                        {statsLoading ? "..." : computedStats.completedProjects.toLocaleString()}
+                      </span>
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-gray-600">월간 성장률</span>
-                      <span className="font-semibold text-green-600">+{mockStats.monthlyGrowth}%</span>
+                      <span className="font-semibold text-green-600">
+                        {statsLoading
+                          ? "..."
+                          : `${computedStats.monthlyGrowth >= 0 ? "+" : ""}${computedStats.monthlyGrowth.toFixed(1)}%`}
+                      </span>
                     </div>
                   </div>
                 </CardContent>
@@ -296,33 +450,21 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-4">
-                    <div className="flex items-center space-x-3">
-                      <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
-                        <Users className="w-4 h-4 text-blue-600" />
+                    {alerts.slice(0, 3).map((alert: any) => (
+                      <div key={alert.id} className="flex items-center space-x-3">
+                        <div className="w-8 h-8 bg-blue-100 rounded-full flex items-center justify-center">
+                          {getAlertIcon(alert.type)}
+                        </div>
+                        <div>
+                          <p className="text-sm font-medium">{alert.title}</p>
+                          <p className="text-xs text-gray-500">{formatRelativeTime(alert.timestamp)}</p>
+                        </div>
                       </div>
-                      <div>
-                        <p className="text-sm font-medium">새로운 사용자가 가입했습니다</p>
-                        <p className="text-xs text-gray-500">10분 전</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-3">
-                      <div className="w-8 h-8 bg-green-100 rounded-full flex items-center justify-center">
-                        <CheckCircle className="w-4 h-4 text-green-600" />
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium">프로젝트가 승인되었습니다</p>
-                        <p className="text-xs text-gray-500">1시간 전</p>
-                      </div>
-                    </div>
-                    <div className="flex items-center space-x-3">
-                      <div className="w-8 h-8 bg-purple-100 rounded-full flex items-center justify-center">
-                        <DollarSign className="w-4 h-4 text-purple-600" />
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium">새로운 후원이 발생했습니다</p>
-                        <p className="text-xs text-gray-500">2시간 전</p>
-                      </div>
-                    </div>
+                    ))}
+
+                    {alerts.length === 0 && (
+                      <p className="text-sm text-gray-500">최근 활동 내역이 없습니다.</p>
+                    )}
                   </div>
                 </CardContent>
               </Card>
@@ -335,38 +477,48 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <h3 className="text-lg font-semibold">사용자 관리</h3>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {mockUsers.map((user) => (
-                    <div key={user.id} className="flex items-center justify-between p-4 border border-gray-200 rounded-lg">
-                      <div className="flex items-center space-x-4">
-                        <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center">
-                          <Users className="w-5 h-5 text-primary-600" />
+                {usersLoading ? (
+                  <ProjectListSkeleton />
+                ) : usersError ? (
+                  <ErrorMessage error={usersError as Error} onRetry={() => refetchUsers()} />
+                ) : normalizedUsers.length > 0 ? (
+                  <div className="space-y-4">
+                    {normalizedUsers.map((user) => (
+                      <div key={user.id} className="flex items-center justify-between p-4 border border-gray-200 rounded-lg">
+                        <div className="flex items-center space-x-4">
+                          <div className="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center">
+                            <Users className="w-5 h-5 text-primary-600" />
+                          </div>
+                          <div>
+                            <h4 className="font-semibold text-gray-900">{user.name}</h4>
+                            <p className="text-sm text-gray-600">{user.email}</p>
+                            <p className="text-xs text-gray-500">
+                              가입일: {user.joinDate ? new Date(user.joinDate).toLocaleDateString() : "정보 없음"}
+                            </p>
+                          </div>
                         </div>
-                        <div>
-                          <h4 className="font-semibold text-gray-900">{user.name}</h4>
-                          <p className="text-sm text-gray-600">{user.email}</p>
-                          <p className="text-xs text-gray-500">가입일: {user.joinDate}</p>
+                        <div className="flex items-center space-x-4">
+                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status)}`}>
+                            {getStatusText(user.status)}
+                          </span>
+                          <div className="flex space-x-2">
+                            <Button variant="ghost" size="sm" onClick={() => onUserAction?.("view", user.id)}>
+                              <Eye className="w-4 h-4" />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => onUserAction?.("edit", user.id)}>
+                              <Edit className="w-4 h-4" />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => onUserAction?.("suspend", user.id)}>
+                              <Shield className="w-4 h-4" />
+                            </Button>
+                          </div>
                         </div>
                       </div>
-                      <div className="flex items-center space-x-4">
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(user.status)}`}>
-                          {getStatusText(user.status)}
-                        </span>
-                        <div className="flex space-x-2">
-                          <Button variant="ghost" size="sm" onClick={() => onUserAction?.('view', user.id)}>
-                            <Eye className="w-4 h-4" />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => onUserAction?.('edit', user.id)}>
-                            <Edit className="w-4 h-4" />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => onUserAction?.('suspend', user.id)}>
-                            <Shield className="w-4 h-4" />
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">표시할 사용자가 없습니다.</p>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -377,39 +529,47 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <h3 className="text-lg font-semibold">프로젝트 관리</h3>
               </CardHeader>
               <CardContent>
-                <div className="space-y-4">
-                  {mockProjects.map((project) => (
-                    <div key={project.id} className="flex items-center justify-between p-4 border border-gray-200 rounded-lg">
-                      <div className="flex-1">
-                        <h4 className="font-semibold text-gray-900">{project.title}</h4>
-                        <p className="text-sm text-gray-600">by {project.artist}</p>
-                        <div className="flex items-center space-x-4 mt-2 text-sm text-gray-500">
-                          <span>목표: {formatCurrency(project.targetAmount)}</span>
-                          <span>•</span>
-                          <span>현재: {formatCurrency(project.amount)}</span>
-                          <span>•</span>
-                          <span>후원자: {project.backers}명</span>
+                {projectsLoading ? (
+                  <ProjectListSkeleton />
+                ) : projectsError ? (
+                  <ErrorMessage error={projectsError as Error} onRetry={() => refetchProjects()} />
+                ) : normalizedProjects.length > 0 ? (
+                  <div className="space-y-4">
+                    {normalizedProjects.map((project) => (
+                      <div key={project.id} className="flex items-center justify-between p-4 border border-gray-200 rounded-lg">
+                        <div className="flex-1">
+                          <h4 className="font-semibold text-gray-900">{project.title}</h4>
+                          <p className="text-sm text-gray-600">by {project.artist}</p>
+                          <div className="flex items-center space-x-4 mt-2 text-sm text-gray-500">
+                            <span>목표: {formatCurrency(project.targetAmount)}</span>
+                            <span>•</span>
+                            <span>현재: {formatCurrency(project.amount)}</span>
+                            <span>•</span>
+                            <span>후원자: {project.backers.toLocaleString()}명</span>
+                          </div>
+                        </div>
+                        <div className="flex items-center space-x-4">
+                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(project.status)}`}>
+                            {getStatusText(project.status)}
+                          </span>
+                          <div className="flex space-x-2">
+                            <Button variant="ghost" size="sm" onClick={() => onProjectAction?.("view", project.id)}>
+                              <Eye className="w-4 h-4" />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => onProjectAction?.("approve", project.id)}>
+                              <CheckCircle className="w-4 h-4" />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => onProjectAction?.("reject", project.id)}>
+                              <XCircle className="w-4 h-4" />
+                            </Button>
+                          </div>
                         </div>
                       </div>
-                      <div className="flex items-center space-x-4">
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusColor(project.status)}`}>
-                          {getStatusText(project.status)}
-                        </span>
-                        <div className="flex space-x-2">
-                          <Button variant="ghost" size="sm" onClick={() => onProjectAction?.('view', project.id)}>
-                            <Eye className="w-4 h-4" />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => onProjectAction?.('approve', project.id)}>
-                            <CheckCircle className="w-4 h-4" />
-                          </Button>
-                          <Button variant="ghost" size="sm" onClick={() => onProjectAction?.('reject', project.id)}>
-                            <XCircle className="w-4 h-4" />
-                          </Button>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-gray-500">검토할 프로젝트가 없습니다.</p>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
@@ -420,10 +580,7 @@ const AdminDashboardSystem: React.FC<AdminDashboardSystemProps> = ({
                 <h3 className="text-lg font-semibold">시스템 설정</h3>
               </CardHeader>
               <CardContent>
-                <div className="text-center py-12">
-                  <Settings className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <p className="text-gray-500">시스템 설정 페이지를 준비 중입니다</p>
-                </div>
+                <p className="text-sm text-gray-500">시스템 설정 기능은 곧 제공될 예정입니다.</p>
               </CardContent>
             </Card>
           </TabsContent>

--- a/src/components/__tests__/FanMyPage.test.tsx
+++ b/src/components/__tests__/FanMyPage.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import FanMyPage from '../FanMyPage';
+import { userProfileAPI } from '../../services/api';
+import { useAuth } from '../../contexts/AuthContext';
+
+type UserProfileAPI = typeof userProfileAPI;
+
+jest.mock('../../services/api', () => ({
+  userProfileAPI: {
+    getUserProfile: jest.fn(),
+    getUserBackings: jest.fn(),
+  },
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+const mockGetUserProfile = userProfileAPI.getUserProfile as jest.MockedFunction<UserProfileAPI['getUserProfile']>;
+const mockGetUserBackings = userProfileAPI.getUserBackings as jest.MockedFunction<UserProfileAPI['getUserBackings']>;
+
+const renderComponent = () => {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FanMyPage />
+    </QueryClientProvider>
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({
+    user: {
+      id: 'user-1',
+      name: '테스트 팬',
+      email: 'fan@example.com',
+      role: 'fan',
+    },
+    token: 'token',
+    isAuthenticated: true,
+    login: jest.fn(),
+    logout: jest.fn(),
+    updateUser: jest.fn(),
+  } as any);
+});
+
+describe('FanMyPage', () => {
+  it('renders profile and backings from the API', async () => {
+    mockGetUserProfile.mockResolvedValue({
+      data: {
+        id: 'user-1',
+        name: '테스트 팬',
+        email: 'fan@example.com',
+        bio: '팬 소개입니다.',
+        totalPledges: 3,
+        totalAmount: 150000,
+        followingCount: 2,
+        following: [
+          { id: 'artist-1', name: '아티스트 A', followers: 1234 },
+        ],
+      },
+    } as any);
+
+    mockGetUserBackings.mockResolvedValue({
+      data: [
+        {
+          id: 'pledge-1',
+          projectId: 'project-1',
+          projectTitle: '새로운 앨범 프로젝트',
+          artistName: '김아티스트',
+          amount: 50000,
+          status: 'completed',
+          pledgeDate: new Date().toISOString(),
+          rewardTitle: '디지털 앨범',
+        },
+      ],
+    } as any);
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(mockGetUserProfile).toHaveBeenCalledWith('user-1');
+      expect(mockGetUserBackings).toHaveBeenCalledWith('user-1', { limit: 20 });
+    });
+
+    expect(await screen.findByText('테스트 팬')).toBeInTheDocument();
+    expect(screen.getByText('fan@example.com')).toBeInTheDocument();
+    expect(screen.getByText('₩150,000')).toBeInTheDocument();
+    expect(
+      screen.getByText((content, element) => element?.textContent === '3' && element.tagName === 'DIV')
+    ).toBeInTheDocument();
+    expect(screen.getByText('팔로잉')).toBeInTheDocument();
+    expect(await screen.findByText('새로운 앨범 프로젝트')).toBeInTheDocument();
+    expect(screen.getByText(/디지털 앨범/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate the community main surface with the useCommunityPosts hook, synchronize filters with the URL, and surface loading/error states
- replace AdminDashboardSystem mock data with stats/admin service queries and show realtime API-driven metrics with proper fallbacks
- load FanMyPage content from the user profile APIs and add a regression test covering the fetched data flow

## Testing
- npm install *(fails: 403 Forbidden while fetching eslint from the registry)*

------
https://chatgpt.com/codex/tasks/task_b_68cdf16fd0f88326b0a059327cfe8dbd