### PR TITLE
Normalize funding project listings

### DIFF
--- a/server/routes/funding.js
+++ b/server/routes/funding.js
@@ -39,6 +39,7 @@ router.get('/projects', async (req, res) => {
       id: project._id,
       title: project.title,
       description: project.description,
+      shortDescription: project.shortDescription || (project.description ? project.description.slice(0, 120) : ''),
       artist: project.artist?.name || project.artistName,
       category: project.category,
       goalAmount: project.goalAmount,
@@ -47,8 +48,14 @@ router.get('/projects', async (req, res) => {
       daysLeft: project.daysLeft,
       progress: project.progress,
       status: project.status,
+      startDate: project.startDate,
+      endDate: project.endDate,
       image: project.image,
-      tags: project.tags
+      tags: project.tags,
+      featured: project.featured || false,
+      isActive: project.isActive,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt
     }));
 
     res.json({

--- a/src/features/funding/__fixtures__/fundingProjects.ts
+++ b/src/features/funding/__fixtures__/fundingProjects.ts
@@ -1,0 +1,71 @@
+import { ApiResponse } from '@/shared/types';
+
+type FundingProjectApiFixture = {
+  id: string;
+  title: string;
+  description: string;
+  goalAmount: number;
+  currentAmount: number;
+  status: string;
+  startDate: string;
+  endDate: string;
+  daysLeft: number;
+  progress: number;
+  image: string;
+  tags: string[];
+  backers: number;
+  featured: boolean;
+  category: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const now = Date.now();
+const sevenDays = 7 * 24 * 60 * 60 * 1000;
+const fourteenDays = 14 * 24 * 60 * 60 * 1000;
+
+export const fundingProjectsApiResponse: ApiResponse<{ projects: FundingProjectApiFixture[] }> = {
+  success: true,
+  data: {
+    projects: [
+      {
+        id: 'project-1',
+        title: '테스트 프로젝트 1',
+        description: '이것은 첫 번째 테스트 프로젝트에 대한 상세 설명입니다. 다양한 콘텐츠 제작과 이벤트를 포함하고 있습니다.',
+        goalAmount: 1000000,
+        currentAmount: 450000,
+        status: '진행중',
+        startDate: new Date(now - sevenDays).toISOString(),
+        endDate: new Date(now + fourteenDays).toISOString(),
+        daysLeft: 14,
+        progress: 45,
+        image: 'https://example.com/project-1.jpg',
+        tags: ['음악', '라이브'],
+        backers: 125,
+        featured: true,
+        category: 'music',
+        createdAt: new Date(now - sevenDays).toISOString(),
+        updatedAt: new Date(now).toISOString(),
+      },
+      {
+        id: 'project-2',
+        title: '테스트 프로젝트 2',
+        description: '두 번째 테스트 프로젝트입니다. 짧은 설명만 제공되어 요약 처리 로직을 검증합니다.',
+        goalAmount: 2000000,
+        currentAmount: 2000000,
+        status: '성공',
+        startDate: new Date(now - fourteenDays).toISOString(),
+        endDate: new Date(now + sevenDays).toISOString(),
+        daysLeft: 7,
+        progress: 100,
+        image: 'https://example.com/project-2.jpg',
+        tags: ['아트', '전시'],
+        backers: 320,
+        featured: false,
+        category: 'art',
+        createdAt: new Date(now - fourteenDays).toISOString(),
+        updatedAt: new Date(now).toISOString(),
+      },
+    ],
+  },
+};

--- a/src/features/funding/components/FundingProjectList/__tests__/ProjectGrid.integration.test.tsx
+++ b/src/features/funding/components/FundingProjectList/__tests__/ProjectGrid.integration.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ProjectGrid from '../ProjectGrid';
+import { fundingService } from '../../../services/fundingService';
+import { api } from '@/lib/api/api';
+import { fundingProjectsApiResponse } from '../../../__fixtures__/fundingProjects';
+
+jest.mock('@/lib/api/api', () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+describe('ProjectGrid', () => {
+  beforeEach(() => {
+    mockedApi.get.mockReset();
+  });
+
+  it('renders projects mapped from the funding API payload', async () => {
+    mockedApi.get.mockResolvedValue(fundingProjectsApiResponse);
+
+    const projects = await fundingService.getProjects();
+
+    render(<ProjectGrid projects={projects} />);
+
+    expect(screen.getByText('테스트 프로젝트 1')).toBeInTheDocument();
+    expect(screen.getByText('테스트 프로젝트 2')).toBeInTheDocument();
+    expect(screen.getByText('추천')).toBeInTheDocument();
+    expect(screen.getByText(/첫 번째 테스트 프로젝트에 대한/)).toBeInTheDocument();
+  });
+});

--- a/src/features/funding/services/__tests__/fundingService.test.ts
+++ b/src/features/funding/services/__tests__/fundingService.test.ts
@@ -1,0 +1,75 @@
+import { fundingService } from '../fundingService';
+import { api } from '@/lib/api/api';
+import { fundingProjectsApiResponse } from '../../__fixtures__/fundingProjects';
+import { FundingProjectStatus } from '../../types';
+
+jest.mock('@/lib/api/api', () => ({
+  api: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockedApi = api as jest.Mocked<typeof api>;
+
+describe('fundingService.getProjects', () => {
+  beforeEach(() => {
+    mockedApi.get.mockReset();
+  });
+
+  it('maps API responses to FundingProject entities', async () => {
+    mockedApi.get.mockResolvedValue(fundingProjectsApiResponse);
+
+    const projects = await fundingService.getProjects();
+
+    expect(mockedApi.get).toHaveBeenCalled();
+    expect(projects).toHaveLength(2);
+    expect(projects[0]).toMatchObject({
+      id: 'project-1',
+      title: '테스트 프로젝트 1',
+      shortDescription: expect.any(String),
+      targetAmount: 1000000,
+      currentAmount: 450000,
+      status: FundingProjectStatus.COLLECTING,
+      images: ['https://example.com/project-1.jpg'],
+      isFeatured: true,
+      backerCount: 125,
+    });
+    expect(projects[0].shortDescription.length).toBeGreaterThan(0);
+    expect(projects[1]).toMatchObject({
+      id: 'project-2',
+      status: FundingProjectStatus.SUCCEEDED,
+      isFeatured: false,
+    });
+  });
+
+  it('filters projects without identifiers', async () => {
+    mockedApi.get.mockResolvedValue({
+      success: true,
+      data: {
+        projects: [
+          {
+            title: '식별자 없는 프로젝트',
+            goalAmount: 100000,
+            currentAmount: 50000,
+          },
+        ],
+      },
+    });
+
+    const projects = await fundingService.getProjects();
+
+    expect(projects).toHaveLength(0);
+  });
+
+  it('throws when the API responds with an error', async () => {
+    mockedApi.get.mockResolvedValue({
+      success: false,
+      message: '프로젝트를 불러오지 못했습니다.',
+    });
+
+    await expect(fundingService.getProjects()).rejects.toThrow('프로젝트를 불러오지 못했습니다.');
+  });
+});

--- a/src/features/funding/types/index.ts
+++ b/src/features/funding/types/index.ts
@@ -12,31 +12,34 @@ export enum FundingProjectStatus {
 }
 
 // 펀딩 프로젝트
-export interface FundingProject extends BaseEntity {
+export interface FundingProject {
+    id: string;
     title: string;
     description: string;
     shortDescription: string;
     targetAmount: number; // 목표 금액 (원 단위)
     currentAmount: number; // 현재 모금액 (원 단위)
     status: FundingProjectStatus;
-    startDate: Date;
-    endDate: Date;
-    daysLeft: number; // 남은 일수
-    ownerId: string;
-    owner: User;
-    categoryId: string;
-    category: Category;
+    startDate?: Date | string;
+    endDate?: Date | string;
+    daysLeft?: number; // 남은 일수
+    ownerId?: string;
+    owner?: User;
+    categoryId?: string;
+    category?: Category | string;
     images: string[];
     tags: string[];
-    rewards: Reward[];
-    pledges: Pledge[];
-    executions: Execution[];
-    distributions: Distribution[];
+    rewards?: Reward[];
+    pledges?: Pledge[];
+    executions?: Execution[];
+    distributions?: Distribution[];
     progress: number; // 진행률 (0-100)
     backerCount: number; // 후원자 수
-    isActive: boolean;
+    isActive?: boolean;
     isFeatured: boolean;
-    metadata: Record<string, any>;
+    metadata?: Record<string, any>;
+    createdAt?: Date | string;
+    updatedAt?: Date | string;
 }
 
 // 리워드


### PR DESCRIPTION
## Summary
- unwrap the funding projects endpoint and map backend field names and statuses to the FundingProject domain model
- relax the FundingProject type to support optional backend fields while still providing defaults for the grid
- expose short descriptions and featured flags from the mock server and add fixtures plus tests proving the grid renders the mapped payload

## Testing
- `npm test -- fundingService` *(fails: jest not installed in environment; npm install blocked by registry permissions)*

------
https://chatgpt.com/codex/tasks/task_b_68cdfb45019083268e42a7623dbde376