### PR TITLE
feat: map funding project detail data

### DIFF
--- a/server/routes/funding.js
+++ b/server/routes/funding.js
@@ -220,14 +220,59 @@ router.get('/projects/:id', async (req, res) => {
     // 달성률 계산
     const progressPercentage = Math.min((project.currentAmount / project.goalAmount) * 100, 100);
     
-    // 응답 데이터 가공
+    const formatDate = (value) => {
+      if (!value) return '';
+      const date = value instanceof Date ? value : new Date(value);
+      return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+    };
+
+    const backersList = Array.isArray(project.backers)
+      ? project.backers.map(backer => ({
+          id: backer._id ? backer._id.toString() : undefined,
+          userId: backer.user ? backer.user.toString() : undefined,
+          userName: backer.isAnonymous ? '익명 후원자' : (backer.userName || '익명 후원자'),
+          amount: backer.amount || 0,
+          date: formatDate(backer.backedAt),
+          status: backer.status || '완료'
+        }))
+      : [];
+
+    const revenueInfo = project.revenueDistribution || {};
+    const totalRevenue = revenueInfo.totalRevenue ?? project.currentAmount ?? 0;
+
+    const createShare = (shareValue) => {
+      if (shareValue && typeof shareValue === 'object') {
+        const percentage = typeof shareValue.percentage === 'number'
+          ? shareValue.percentage
+          : totalRevenue > 0 && typeof shareValue.amount === 'number'
+            ? Number(((shareValue.amount / totalRevenue) * 100).toFixed(2))
+            : 0;
+
+        const amount = typeof shareValue.amount === 'number'
+          ? shareValue.amount
+          : typeof shareValue.percentage === 'number'
+            ? Number(((shareValue.percentage / 100) * totalRevenue).toFixed(0))
+            : 0;
+
+        return { amount, percentage };
+      }
+
+      const ratio = typeof shareValue === 'number' ? shareValue : 0;
+      return {
+        amount: Number((ratio * totalRevenue).toFixed(0)),
+        percentage: Number((ratio * 100).toFixed(2))
+      };
+    };
+
     const formattedProject = {
-      id: project._id,
+      id: project._id ? project._id.toString() : projectId,
       title: project.title,
       description: project.description,
       artist: project.artist?.name || project.artistName,
+      artistId: project.artist?._id ? project.artist._id.toString() : undefined,
       category: project.category,
       goalAmount: project.goalAmount,
+      targetAmount: project.goalAmount,
       currentAmount: project.currentAmount,
       backers: project.backers?.length || 0,
       daysLeft: Math.max(0, daysLeft),
@@ -236,17 +281,36 @@ router.get('/projects/:id', async (req, res) => {
       progressPercentage: Math.round(progressPercentage),
       startDate: project.startDate,
       endDate: project.endDate,
+      story: project.story || project.description,
+      artistAvatar: project.artist?.avatar || '',
+      artistRating: project.artist?.rating || 0,
+      featured: Boolean(project.featured),
       rewards: project.rewards || [],
       updates: project.updates || [],
       tags: project.tags || [],
-      executionPlan: project.executionPlan || { stages: [], totalBudget: project.goalAmount },
+      executionPlan: {
+        stages: project.executionPlan?.stages || [],
+        totalBudget: project.executionPlan?.totalBudget ?? project.goalAmount
+      },
       expenseRecords: project.expenseRecords || [],
-      revenueDistribution: project.revenueDistribution || {
-        totalRevenue: 0,
-        platformFee: 0.05,
-        artistShare: 0.70,
-        backerShare: 0.25,
-        distributions: []
+      backersList,
+      revenueDistribution: {
+        totalRevenue,
+        platformFee: createShare(revenueInfo.platformFee),
+        artistShare: createShare(revenueInfo.artistShare),
+        backerShare: createShare(revenueInfo.backerShare),
+        distributions: Array.isArray(revenueInfo.distributions)
+          ? revenueInfo.distributions.map(distribution => ({
+              id: distribution._id ? distribution._id.toString() : undefined,
+              backer: distribution.backer ? distribution.backer.toString() : undefined,
+              userName: distribution.userName || '익명 후원자',
+              originalAmount: distribution.originalAmount || 0,
+              profitShare: distribution.profitShare || 0,
+              amount: distribution.totalReturn || distribution.amount || 0,
+              date: formatDate(distribution.distributedAt || distribution.date),
+              status: distribution.status || '대기'
+            }))
+          : []
       }
     };
 

--- a/src/__tests__/APIService.test.tsx
+++ b/src/__tests__/APIService.test.tsx
@@ -198,17 +198,18 @@ describe('API 서비스 테스트', () => {
                 json: async () => ({ success: true, data: mockProject })
             });
 
-            const result = await fundingAPI.getProject('1') as any;
+            const result = await fundingAPI.getProject('1');
 
-            expect(global.fetch).toHaveBeenCalledWith(
-                expect.stringContaining('/api/projects/1'),
+            expect(result).toEqual(
                 expect.objectContaining({
-                    method: 'GET'
+                    id: expect.any(String),
+                    title: mockProject.title,
+                    description: mockProject.description,
+                    currentAmount: mockProject.currentAmount,
+                    targetAmount: mockProject.targetAmount,
+                    backers: mockProject.backers
                 })
             );
-
-            expect(result.success).toBe(true);
-            expect(result.data).toEqual(mockProject);
         });
     });
 

--- a/src/__tests__/FundingSystem.test.tsx
+++ b/src/__tests__/FundingSystem.test.tsx
@@ -332,7 +332,7 @@ describe('펀딩 시스템 기본 테스트', () => {
             });
 
             // description이 누락된 경우 기본값 표시 (프로젝트 헤더에서 확인)
-            expect(screen.getByText('프로젝트 설명이 없습니다.', { selector: '.text-gray-600.text-lg.mb-4' })).toBeInTheDocument();
+            expect(screen.getByText('프로젝트 설명이 등록되지 않았습니다.', { selector: '.text-gray-600.text-lg.mb-4' })).toBeInTheDocument();
         });
     });
 });

--- a/src/components/FundingProjectDetail/ProjectHeader.tsx
+++ b/src/components/FundingProjectDetail/ProjectHeader.tsx
@@ -29,6 +29,14 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
     onShare,
     onSupport
 }) => {
+    const projectImage = project.image;
+    const artistInitial = project.artist?.charAt?.(0) ?? '아';
+    const progress = project.progressPercentage ?? 0;
+    const currentAmount = project.currentAmount ?? 0;
+    const backerCount = project.backers ?? 0;
+    const daysLeft = project.daysLeft ?? 0;
+    const category = project.category ?? '카테고리 미정';
+
     return (
         <div className="space-y-6">
             {/* 뒤로가기 버튼 */}
@@ -43,11 +51,17 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
 
             {/* 프로젝트 이미지 */}
             <div className="relative">
-                <img
-                    src={project.image}
-                    alt={project.title}
-                    className="w-full h-64 object-cover rounded-lg"
-                />
+                {projectImage ? (
+                    <img
+                        src={projectImage}
+                        alt={project.title || '프로젝트 이미지'}
+                        className="w-full h-64 object-cover rounded-lg"
+                    />
+                ) : (
+                    <div className="w-full h-64 rounded-lg bg-gray-200 flex items-center justify-center text-gray-500">
+                        이미지가 없습니다
+                    </div>
+                )}
                 <div className="absolute top-4 right-4 flex gap-2">
                     <Button
                         variant="secondary"
@@ -72,21 +86,21 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
             <div className="space-y-4">
                 <div className="flex items-start justify-between">
                     <div className="space-y-2">
-                        <h1 className="text-3xl font-bold">{project.title}</h1>
-                        <p className="text-gray-600">{project.description}</p>
+                        <h1 className="text-3xl font-bold">{project.title || '제목 미정'}</h1>
+                        <p className="text-gray-600">{project.description || '프로젝트 설명이 등록되지 않았습니다.'}</p>
                     </div>
                     <Badge variant="outline" className="text-sm">
-                        {project.category}
+                        {category}
                     </Badge>
                 </div>
 
                 {/* 아티스트 정보 */}
                 <div className="flex items-center gap-3">
                     <Avatar className="h-10 w-10">
-                        <AvatarFallback>{project.artist.charAt(0)}</AvatarFallback>
+                        <AvatarFallback>{artistInitial}</AvatarFallback>
                     </Avatar>
                     <div>
-                        <p className="font-medium">{project.artist}</p>
+                        <p className="font-medium">{project.artist || '알 수 없는 아티스트'}</p>
                         <p className="text-sm text-gray-500">아티스트</p>
                     </div>
                 </div>
@@ -95,25 +109,25 @@ export const ProjectHeader: React.FC<ProjectHeaderProps> = ({
                 <div className="space-y-2">
                     <div className="flex justify-between text-sm">
                         <span>진행률</span>
-                        <span>{project.progressPercentage}%</span>
+                        <span>{progress}%</span>
                     </div>
-                    <Progress value={project.progressPercentage} className="h-2" />
+                    <Progress value={progress} className="h-2" />
                 </div>
 
                 {/* 통계 */}
                 <div className="grid grid-cols-3 gap-4">
                     <div className="text-center">
                         <div className="text-2xl font-bold text-green-600">
-                            {project.currentAmount.toLocaleString()}원
+                            {currentAmount.toLocaleString()}원
                         </div>
                         <div className="text-sm text-gray-500">모금액</div>
                     </div>
                     <div className="text-center">
-                        <div className="text-2xl font-bold">{project.backers}</div>
+                        <div className="text-2xl font-bold">{backerCount}</div>
                         <div className="text-sm text-gray-500">후원자</div>
                     </div>
                     <div className="text-center">
-                        <div className="text-2xl font-bold">{project.daysLeft}</div>
+                        <div className="text-2xl font-bold">{daysLeft}</div>
                         <div className="text-sm text-gray-500">남은 일수</div>
                     </div>
                 </div>

--- a/src/components/FundingProjectDetail/ProjectTabs.tsx
+++ b/src/components/FundingProjectDetail/ProjectTabs.tsx
@@ -11,6 +11,18 @@ interface ProjectTabsProps {
 }
 
 export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
+    const rewards = project.rewards ?? [];
+    const updates = project.updates ?? [];
+    const backers = project.backersList ?? [];
+    const stages = project.executionPlan?.stages ?? [];
+    const expenses = project.expenseRecords ?? [];
+    const revenueDistribution = project.revenueDistribution;
+
+    const totalRevenue = revenueDistribution?.totalRevenue ?? 0;
+    const artistShareAmount = revenueDistribution?.artistShare?.amount ?? 0;
+    const artistSharePercentage = revenueDistribution?.artistShare?.percentage ?? 0;
+    const distributions = revenueDistribution?.distributions ?? [];
+
     return (
         <Tabs defaultValue="overview" className="w-full">
             <TabsList className="grid w-full grid-cols-4">
@@ -21,19 +33,19 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
             </TabsList>
 
             <TabsContent value="overview" className="space-y-6">
-                <Card>
-                    <CardHeader>
-                        <CardTitle className="flex items-center gap-2">
-                            <FileText className="h-5 w-5" />
-                            프로젝트 소개
-                        </CardTitle>
-                    </CardHeader>
-                    <CardContent>
-                        <p className="text-gray-700 leading-relaxed">
-                            {project.description}
-                        </p>
-                    </CardContent>
-                </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle className="flex items-center gap-2">
+                                <FileText className="h-5 w-5" />
+                                프로젝트 소개
+                            </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p className="text-gray-700 leading-relaxed">
+                                {project.description || '프로젝트 소개가 아직 등록되지 않았습니다.'}
+                            </p>
+                        </CardContent>
+                    </Card>
 
                 {/* 리워드 목록 */}
                 <Card>
@@ -41,7 +53,9 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                         <CardTitle>리워드</CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-4">
-                        {project.rewards.map((reward) => (
+                        {rewards.length === 0 ? (
+                            <p className="text-sm text-gray-500">등록된 리워드가 없습니다.</p>
+                        ) : rewards.map((reward) => (
                             <div
                                 key={reward.id}
                                 className="border rounded-lg p-4 space-y-2"
@@ -53,33 +67,39 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                             {reward.description}
                                         </p>
                                     </div>
-                                    <div className="text-right">
-                                        <div className="font-bold text-lg">
-                                            {reward.amount.toLocaleString()}원
-                                        </div>
-                                        <div className="text-sm text-gray-500">
-                                            예상 전달일: {reward.estimatedDelivery}
+                                        <div className="text-right">
+                                            <div className="font-bold text-lg">
+                                                {(reward.amount ?? 0).toLocaleString()}원
+                                            </div>
+                                            <div className="text-sm text-gray-500">
+                                                예상 전달일: {reward.estimatedDelivery ? new Date(reward.estimatedDelivery).toLocaleDateString() : '미정'}
+                                            </div>
                                         </div>
                                     </div>
+                                    {reward.maxClaim && (
+                                        <div className="flex justify-between text-sm text-gray-500">
+                                            <span>
+                                                {(reward.claimed ?? 0)} / {reward.maxClaim}명 선택
+                                            </span>
+                                            <span>
+                                                {reward.maxClaim ? Math.round(((reward.claimed ?? 0) / reward.maxClaim) * 100) : 0}% 완료
+                                            </span>
+                                        </div>
+                                    )}
                                 </div>
-                                {reward.maxClaim && (
-                                    <div className="flex justify-between text-sm text-gray-500">
-                                        <span>
-                                            {reward.claimed || 0} / {reward.maxClaim}명 선택
-                                        </span>
-                                        <span>
-                                            {Math.round(((reward.claimed || 0) / reward.maxClaim) * 100)}% 완료
-                                        </span>
-                                    </div>
-                                )}
-                            </div>
                         ))}
                     </CardContent>
                 </Card>
             </TabsContent>
 
             <TabsContent value="updates" className="space-y-4">
-                {project.updates.map((update) => (
+                {updates.length === 0 ? (
+                    <Card>
+                        <CardContent className="p-6 text-sm text-gray-500">
+                            아직 등록된 업데이트가 없습니다.
+                        </CardContent>
+                    </Card>
+                ) : updates.map((update) => (
                     <Card key={update.id}>
                         <CardHeader>
                             <div className="flex justify-between items-start">
@@ -89,7 +109,7 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                 </Badge>
                             </div>
                             <p className="text-sm text-gray-500">
-                                {update.date}
+                                {update.date ? new Date(update.date).toLocaleString() : ''}
                             </p>
                         </CardHeader>
                         <CardContent>
@@ -103,26 +123,32 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
 
             <TabsContent value="backers" className="space-y-4">
                 <div className="grid gap-4">
-                    {project.backersList.map((backer) => (
+                    {backers.length === 0 ? (
+                        <Card>
+                            <CardContent className="p-6 text-sm text-gray-500 text-center">
+                                아직 후원자가 없습니다.
+                            </CardContent>
+                        </Card>
+                    ) : backers.map((backer) => (
                         <Card key={backer.id}>
                             <CardContent className="p-4">
                                 <div className="flex items-center justify-between">
                                     <div className="flex items-center gap-3">
                                         <Avatar className="h-8 w-8">
                                             <AvatarFallback>
-                                                {backer.userName.charAt(0)}
+                                                {backer.userName?.charAt?.(0) ?? '익'}
                                             </AvatarFallback>
                                         </Avatar>
                                         <div>
                                             <p className="font-medium">{backer.userName}</p>
                                             <p className="text-sm text-gray-500">
-                                                {backer.date}
+                                                {backer.date ? new Date(backer.date).toLocaleString() : ''}
                                             </p>
                                         </div>
                                     </div>
                                     <div className="text-right">
                                         <div className="font-semibold">
-                                            {backer.amount.toLocaleString()}원
+                                            {(backer.amount ?? 0).toLocaleString()}원
                                         </div>
                                         <Badge
                                             variant={backer.status === '완료' ? 'default' : 'secondary'}
@@ -148,7 +174,9 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-4">
-                        {project.executionPlan.stages.map((stage) => (
+                        {stages.length === 0 ? (
+                            <p className="text-sm text-gray-500">등록된 집행 계획이 없습니다.</p>
+                        ) : stages.map((stage) => (
                             <div
                                 key={stage.id}
                                 className="border rounded-lg p-4 space-y-2"
@@ -162,7 +190,7 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                     </div>
                                     <div className="text-right">
                                         <div className="font-semibold">
-                                            {stage.budget.toLocaleString()}원
+                                            {(stage.budget ?? 0).toLocaleString()}원
                                         </div>
                                         <Badge
                                             variant={
@@ -175,8 +203,8 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                     </div>
                                 </div>
                                 <div className="flex justify-between text-sm text-gray-500">
-                                    <span>{stage.startDate} ~ {stage.endDate}</span>
-                                    <span>진행률: {stage.progress}%</span>
+                                    <span>{stage.startDate ? new Date(stage.startDate).toLocaleDateString() : ''} ~ {stage.endDate ? new Date(stage.endDate).toLocaleDateString() : ''}</span>
+                                    <span>진행률: {(stage.progress ?? 0)}%</span>
                                 </div>
                             </div>
                         ))}
@@ -192,7 +220,9 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                         </CardTitle>
                     </CardHeader>
                     <CardContent className="space-y-4">
-                        {project.expenseRecords.map((expense) => (
+                        {expenses.length === 0 ? (
+                            <p className="text-sm text-gray-500">등록된 지출 내역이 없습니다.</p>
+                        ) : expenses.map((expense) => (
                             <div
                                 key={expense.id}
                                 className="border rounded-lg p-4 space-y-2"
@@ -209,7 +239,7 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                     </div>
                                     <div className="text-right">
                                         <div className="font-semibold">
-                                            {expense.amount.toLocaleString()}원
+                                            {(expense.amount ?? 0).toLocaleString()}원
                                         </div>
                                         <Badge
                                             variant={expense.verified ? 'default' : 'secondary'}
@@ -220,7 +250,7 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                     </div>
                                 </div>
                                 <div className="text-sm text-gray-500">
-                                    {expense.date}
+                                    {expense.date ? new Date(expense.date).toLocaleDateString() : ''}
                                 </div>
                             </div>
                         ))}
@@ -239,21 +269,23 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                         <div className="grid grid-cols-2 gap-4">
                             <div className="text-center p-4 bg-gray-50 rounded-lg">
                                 <div className="text-2xl font-bold text-green-600">
-                                    {project.revenueDistribution.totalRevenue.toLocaleString()}원
+                                    {totalRevenue.toLocaleString()}원
                                 </div>
                                 <div className="text-sm text-gray-500">총 수익</div>
                             </div>
                             <div className="text-center p-4 bg-gray-50 rounded-lg">
                                 <div className="text-2xl font-bold text-blue-600">
-                                    {project.revenueDistribution.artistShare.toLocaleString()}원
+                                    {artistShareAmount.toLocaleString()}원
                                 </div>
-                                <div className="text-sm text-gray-500">아티스트 수익</div>
+                                <div className="text-sm text-gray-500">아티스트 수익 ({artistSharePercentage}%)</div>
                             </div>
                         </div>
 
                         <div className="space-y-2">
                             <h4 className="font-semibold">분배 내역</h4>
-                            {project.revenueDistribution.distributions.map((distribution) => (
+                            {distributions.length === 0 ? (
+                                <p className="text-sm text-gray-500">분배 내역이 없습니다.</p>
+                            ) : distributions.map((distribution) => (
                                 <div
                                     key={distribution.id}
                                     className="flex justify-between items-center p-3 border rounded-lg"
@@ -261,12 +293,12 @@ export const ProjectTabs: React.FC<ProjectTabsProps> = ({ project }) => {
                                     <div>
                                         <p className="font-medium">{distribution.userName}</p>
                                         <p className="text-sm text-gray-500">
-                                            원래 후원: {distribution.originalAmount.toLocaleString()}원
+                                            원래 후원: {(distribution.originalAmount ?? 0).toLocaleString()}원
                                         </p>
                                     </div>
                                     <div className="text-right">
                                         <div className="font-semibold">
-                                            {distribution.amount.toLocaleString()}원
+                                            {(distribution.amount ?? 0).toLocaleString()}원
                                         </div>
                                         <div className="text-sm text-gray-500">
                                             {distribution.profitShare}% 수익

--- a/src/components/FundingProjectDetail/__tests__/ProjectTabs.test.tsx
+++ b/src/components/FundingProjectDetail/__tests__/ProjectTabs.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { ProjectTabs } from '../ProjectTabs';
+import { mapFundingProjectDetail } from '@/services/api';
+
+describe('ProjectTabs detail view', () => {
+    it('renders safely with mapped project response and missing arrays', () => {
+        const rawResponse = {
+            id: 'mapped-project-1',
+            title: '매핑된 프로젝트',
+            description: '매퍼를 통해 변환된 프로젝트입니다.',
+            artist: '테스트 아티스트',
+            category: '음악',
+            goalAmount: 1000000,
+            currentAmount: 500000,
+            backers: 12,
+            daysLeft: 20,
+            image: 'https://example.com/image.jpg',
+            status: '진행중',
+            progressPercentage: 50,
+            startDate: '2024-01-01T00:00:00.000Z',
+            endDate: '2024-02-01T00:00:00.000Z',
+            rewards: null,
+            updates: undefined,
+            backersList: undefined,
+            executionPlan: {
+                stages: null,
+                totalBudget: 1000000,
+            },
+            expenseRecords: null,
+            revenueDistribution: {
+                totalRevenue: 0,
+                platformFee: 0.05,
+                artistShare: 0.7,
+                backerShare: 0.25,
+                distributions: undefined,
+            },
+        };
+
+        const mappedProject = mapFundingProjectDetail(rawResponse);
+
+        expect(mappedProject).not.toBeNull();
+
+        render(<ProjectTabs project={mappedProject!} />);
+
+        expect(screen.getByText('프로젝트 소개')).toBeInTheDocument();
+        expect(screen.getByText('등록된 리워드가 없습니다.')).toBeInTheDocument();
+        expect(screen.getByText('아직 등록된 업데이트가 없습니다.')).toBeInTheDocument();
+        expect(screen.getByText('아직 후원자가 없습니다.')).toBeInTheDocument();
+    });
+});

--- a/src/components/ProjectDetail.tsx
+++ b/src/components/ProjectDetail.tsx
@@ -34,10 +34,10 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
     const fetchProject = async () => {
       try {
         setLoading(true);
-        const response = await fundingAPI.getProject(projectId.toString()) as ApiResponse<any>;
+        const projectData = await fundingAPI.getProject(projectId.toString());
 
-        if (response.success && response.data) {
-          setProject(response.data);
+        if (projectData) {
+          setProject(projectData);
         } else {
           setError('프로젝트를 찾을 수 없습니다.');
         }
@@ -66,9 +66,9 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
 
       if (response.success) {
         // 프로젝트 정보 새로고침
-        const updatedResponse = await fundingAPI.getProject(projectId.toString()) as ApiResponse<any>;
-        if (updatedResponse.success && updatedResponse.data) {
-          setProject(updatedResponse.data);
+        const updatedProject = await fundingAPI.getProject(projectId.toString());
+        if (updatedProject) {
+          setProject(updatedProject);
         }
         setShowPaymentModal(false);
       }
@@ -84,11 +84,11 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
         // 좋아요 상태를 즉시 업데이트
         setIsLiked(!isLiked);
         // 프로젝트 정보 새로고침
-        const updatedResponse = await fundingAPI.getProject(projectId.toString()) as ApiResponse<any>;
-        if (updatedResponse.success && updatedResponse.data) {
+        const updatedProject = await fundingAPI.getProject(projectId.toString());
+        if (updatedProject) {
           setProject((prev: any) => ({
             ...prev,
-            ...updatedResponse.data,
+            ...updatedProject,
             isLiked: !isLiked
           }));
         }
@@ -105,9 +105,9 @@ export function ProjectDetail({ projectId, onBack }: ProjectDetailProps) {
       if (response.success) {
         setIsBookmarked(!isBookmarked);
         // 프로젝트 정보 새로고침
-        const updatedResponse = await fundingAPI.getProject(projectId.toString()) as ApiResponse<any>;
-        if (updatedResponse.success && updatedResponse.data) {
-          setProject(updatedResponse.data);
+        const updatedProject = await fundingAPI.getProject(projectId.toString());
+        if (updatedProject) {
+          setProject(updatedProject);
         }
       }
     } catch (error) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api/api';
-import type { ApiError, ApiRequestConfig } from '@/shared/types';
+import type { ApiError, ApiRequestConfig, ApiResponse } from '@/shared/types';
+import type { FundingProject, RevenueShare } from '@/types/fundingProject';
 
 type ApiCallOptions = RequestInit & {
     params?: Record<string, unknown>;
@@ -51,6 +52,209 @@ class RequestQueue {
 }
 
 const requestQueue = new RequestQueue();
+
+const toArray = <T>(value: T[] | undefined | null): T[] => Array.isArray(value) ? value : [];
+
+const toNumber = (value: unknown, fallback = 0): number => {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    if (typeof value === 'string') {
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : fallback;
+    }
+
+    return fallback;
+};
+
+const toIsoString = (value: unknown): string => {
+    if (!value) {
+        return '';
+    }
+
+    const date = value instanceof Date ? value : new Date(value as string);
+    return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+};
+
+const createId = (value: unknown, prefix: string): string => {
+    if (!value) {
+        return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    if (typeof value === 'string') {
+        return value.trim() !== '' ? value : `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    if (typeof value === 'number') {
+        return String(value);
+    }
+
+    if (typeof value === 'object' && '_id' in (value as Record<string, unknown>)) {
+        return createId((value as Record<string, unknown>)._id, prefix);
+    }
+
+    return String(value);
+};
+
+const mapRevenueShare = (share: unknown, totalRevenue: number): RevenueShare => {
+    if (share && typeof share === 'object' && !Array.isArray(share)) {
+        const shareObject = share as { amount?: unknown; percentage?: unknown };
+        const derivedAmount = typeof shareObject.percentage === 'number'
+            ? Math.round((shareObject.percentage / 100) * totalRevenue)
+            : 0;
+        const amount = toNumber(shareObject.amount, derivedAmount);
+        const percentage = typeof shareObject.percentage === 'number'
+            ? shareObject.percentage
+            : totalRevenue > 0
+                ? Number(((amount / totalRevenue) * 100).toFixed(2))
+                : 0;
+
+        return {
+            amount,
+            percentage,
+        };
+    }
+
+    const ratio = toNumber(share);
+    return {
+        amount: Math.round(ratio * totalRevenue),
+        percentage: Number((ratio * 100).toFixed(2)),
+    };
+};
+
+const extractApiData = <T>(response: ApiResponse<T> | T | undefined): T | null => {
+    if (!response) {
+        return null;
+    }
+
+    if (typeof response === 'object' && 'success' in response) {
+        return (response as ApiResponse<T>).data ?? null;
+    }
+
+    return response as T;
+};
+
+export const mapFundingProjectDetail = (project: any): FundingProject | null => {
+    if (!project) {
+        return null;
+    }
+
+    const totalRevenue = toNumber(project?.revenueDistribution?.totalRevenue, toNumber(project?.currentAmount));
+    const backersArray = project.backersList ?? project.backers;
+
+    const goalAmount = toNumber(project.goalAmount, toNumber(project.targetAmount));
+
+    return {
+        id: createId(project.id ?? project._id, 'project'),
+        title: typeof project.title === 'string' ? project.title : '',
+        description: typeof project.description === 'string' ? project.description : '',
+        artist: typeof project.artist === 'string'
+            ? project.artist
+            : typeof project.artistName === 'string'
+                ? project.artistName
+                : '',
+        category: typeof project.category === 'string' ? project.category : '',
+        goalAmount,
+        targetAmount: toNumber(project.targetAmount, goalAmount),
+        currentAmount: toNumber(project.currentAmount),
+        backers: typeof project.backers === 'number'
+            ? project.backers
+            : Array.isArray(project.backers)
+                ? project.backers.length
+                : Array.isArray(project.backersList)
+                    ? project.backersList.length
+                    : 0,
+        daysLeft: toNumber(project.daysLeft),
+        image: typeof project.image === 'string' ? project.image : '',
+        status: typeof project.status === 'string' ? project.status : '',
+        progressPercentage: toNumber(project.progressPercentage, toNumber(project.progress)),
+        startDate: toIsoString(project.startDate),
+        endDate: toIsoString(project.endDate),
+        story: typeof project.story === 'string' ? project.story : typeof project.description === 'string' ? project.description : undefined,
+        artistAvatar: typeof project.artistAvatar === 'string' ? project.artistAvatar : undefined,
+        artistRating: typeof project.artistRating === 'number' ? project.artistRating : undefined,
+        artistId: project.artistId
+            ? String(project.artistId)
+            : project.artist && typeof project.artist === 'object' && '_id' in project.artist
+                ? String((project.artist as { _id: unknown })._id)
+                : undefined,
+        featured: typeof project.featured === 'boolean' ? project.featured : undefined,
+        rewards: toArray(project.rewards).map((reward: any) => ({
+            id: createId(reward.id ?? reward._id ?? reward.title, 'reward'),
+            title: typeof reward.title === 'string' ? reward.title : '',
+            description: typeof reward.description === 'string' ? reward.description : '',
+            amount: toNumber(reward.amount),
+            estimatedDelivery: toIsoString(reward.estimatedDelivery),
+            claimed: typeof reward.claimed === 'number' ? reward.claimed : undefined,
+            maxClaim: typeof reward.maxClaim === 'number' ? reward.maxClaim : undefined,
+        })),
+        updates: toArray(project.updates).map((update: any) => ({
+            id: createId(update.id ?? update._id ?? update.title, 'update'),
+            title: typeof update.title === 'string' ? update.title : '',
+            content: typeof update.content === 'string' ? update.content : '',
+            date: toIsoString(update.date ?? update.createdAt),
+            type: typeof update.type === 'string' ? update.type : undefined,
+            createdAt: update.createdAt ? toIsoString(update.createdAt) : undefined,
+        })),
+        backersList: toArray(backersArray).map((backer: any) => ({
+            id: createId(backer.id ?? backer._id ?? backer.user, 'backer'),
+            userId: backer.userId
+                ? String(backer.userId)
+                : backer.user
+                    ? String(backer.user)
+                    : undefined,
+            userName: typeof backer.userName === 'string'
+                ? backer.userName
+                : backer.isAnonymous
+                    ? '익명 후원자'
+                    : '익명 후원자',
+            amount: toNumber(backer.amount),
+            date: toIsoString(backer.date ?? backer.backedAt),
+            status: typeof backer.status === 'string' ? backer.status : '완료',
+        })),
+        executionPlan: {
+            stages: toArray(project.executionPlan?.stages).map((stage: any) => ({
+                id: createId(stage.id ?? stage._id ?? stage.name, 'stage'),
+                name: typeof stage.name === 'string' ? stage.name : '',
+                description: typeof stage.description === 'string' ? stage.description : '',
+                budget: toNumber(stage.budget),
+                startDate: toIsoString(stage.startDate),
+                endDate: toIsoString(stage.endDate),
+                status: typeof stage.status === 'string' ? stage.status : '계획',
+                progress: toNumber(stage.progress),
+            })),
+            totalBudget: toNumber(project.executionPlan?.totalBudget, toNumber(project.goalAmount)),
+        },
+        expenseRecords: toArray(project.expenseRecords).map((expense: any) => ({
+            id: createId(expense.id ?? expense._id ?? expense.title, 'expense'),
+            category: typeof expense.category === 'string' ? expense.category : '',
+            title: typeof expense.title === 'string' ? expense.title : '',
+            description: typeof expense.description === 'string' ? expense.description : '',
+            amount: toNumber(expense.amount),
+            date: toIsoString(expense.date),
+            receipt: typeof expense.receipt === 'string' ? expense.receipt : '',
+            stage: expense.stage ? String(expense.stage) : '',
+            verified: Boolean(expense.verified),
+        })),
+        revenueDistribution: {
+            totalRevenue,
+            platformFee: mapRevenueShare(project.revenueDistribution?.platformFee, totalRevenue),
+            artistShare: mapRevenueShare(project.revenueDistribution?.artistShare, totalRevenue),
+            backerShare: mapRevenueShare(project.revenueDistribution?.backerShare, totalRevenue),
+            distributions: toArray(project.revenueDistribution?.distributions).map((distribution: any) => ({
+                id: createId(distribution.id ?? distribution._id ?? distribution.backer, 'distribution'),
+                backer: distribution.backer ? String(distribution.backer) : undefined,
+                userName: typeof distribution.userName === 'string' ? distribution.userName : '익명 후원자',
+                originalAmount: toNumber(distribution.originalAmount),
+                profitShare: toNumber(distribution.profitShare),
+                amount: toNumber(distribution.amount ?? distribution.totalReturn),
+                date: toIsoString(distribution.date ?? distribution.distributedAt),
+                status: typeof distribution.status === 'string' ? distribution.status : '대기',
+            })),
+        },
+    };
+};
 
 // Header Normalizer
 const normalizeHeaders = (headers?: HeadersInit): Record<string, string> | undefined => {
@@ -393,8 +597,14 @@ export const fundingAPI = {
     },
 
     // 프로젝트 상세 조회
-    getProject: (projectId: string) => apiCall(`/funding/projects/${projectId}`),
-    getProjectDetail: (projectId: string) => apiCall(`/funding/projects/${projectId}`),
+    getProject: async (projectId: string): Promise<FundingProject | null> => {
+        const response = await apiCall<ApiResponse<FundingProject>>(`/funding/projects/${projectId}`);
+        return mapFundingProjectDetail(extractApiData(response));
+    },
+    getProjectDetail: async (projectId: string): Promise<FundingProject | null> => {
+        const response = await apiCall<ApiResponse<FundingProject>>(`/funding/projects/${projectId}`);
+        return mapFundingProjectDetail(extractApiData(response));
+    },
 
     // 프로젝트 생성
     createProject: (projectData: any) => apiCall('/funding/projects', {
@@ -441,7 +651,7 @@ export const fundingAPI = {
     }),
 
     // 기존 함수들 (호환성 유지)
-    getProjectDetails: (projectId: number) => apiCall(`/funding/projects/${projectId}`),
+    getProjectDetails: (projectId: number) => fundingAPI.getProjectDetail(String(projectId)),
     investInProject: (projectId: number, amount: number) => apiCall(`/funding/projects/${projectId}/invest`, {
         method: 'POST',
         body: JSON.stringify({ amount })

--- a/src/types/fundingProject.ts
+++ b/src/types/fundingProject.ts
@@ -7,6 +7,7 @@ export interface FundingProject {
     artist: string;
     category: string;
     goalAmount: number;
+    targetAmount?: number;
     currentAmount: number;
     backers: number;
     daysLeft: number;
@@ -15,6 +16,11 @@ export interface FundingProject {
     progressPercentage: number;
     startDate: string;
     endDate: string;
+    story?: string;
+    artistAvatar?: string;
+    artistRating?: number;
+    artistId?: string;
+    featured?: boolean;
     rewards: Reward[];
     updates: ProjectUpdate[];
     backersList: Backer[];
@@ -44,7 +50,7 @@ export interface ProjectUpdate {
 
 export interface Backer {
     id: string;
-    userId: string;
+    userId?: string;
     userName: string;
     amount: number;
     date: string;
@@ -81,7 +87,7 @@ export interface ExpenseRecord {
 
 export interface Distribution {
     id: string;
-    backer: string;
+    backer?: string;
     userName: string;
     originalAmount: number;
     profitShare: number;
@@ -90,10 +96,15 @@ export interface Distribution {
     status: string;
 }
 
+export interface RevenueShare {
+    amount: number;
+    percentage: number;
+}
+
 export interface RevenueDistribution {
     totalRevenue: number;
-    platformFee: number;
-    artistShare: number;
-    backerShare: number;
+    platformFee: RevenueShare;
+    artistShare: RevenueShare;
+    backerShare: RevenueShare;
     distributions: Distribution[];
 }


### PR DESCRIPTION
## Summary
- map project detail responses in the funding API so arrays default to empty collections and revenue share data includes both amount and percentage
- extend the funding detail route to surface backer metadata and share calculations expected by the UI
- guard funding detail components against missing data and add a unit test to ensure the mapped response renders without crashing

## Testing
- `npm test -- --runInBand` *(fails: local jest binary unavailable and npm install blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68cdfb457be883269f8bf4422eea042a