### PR TITLE
fix: adapt auth token handling to legacy responses

### DIFF
--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -26,12 +26,14 @@ export interface SignupData {
 export interface AuthResponse {
     user: User;
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface RefreshTokenResponse {
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface PasswordResetRequest {


### PR DESCRIPTION
## Summary
- sanitize and persist auth tokens even when the API only returns a single `token`
- normalize login, signup, and refresh flows to fallback to legacy token payloads
- extend auth response types to accommodate optional refresh tokens and legacy fields

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser before dependencies could be installed due to restricted registry access)*

------
https://chatgpt.com/codex/tasks/task_b_68ce816e53a883269890688bd33593e9