### PR TITLE
fix: wire community surfaces to live APIs

### DIFF
--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -26,12 +26,14 @@ export interface SignupData {
 export interface AuthResponse {
     user: User;
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface RefreshTokenResponse {
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface PasswordResetRequest {

--- a/src/features/community/types/index.ts
+++ b/src/features/community/types/index.ts
@@ -58,11 +58,11 @@ export interface CommunityCategory {
 
 export interface CommunityStats {
     totalPosts: number;
+    activeUsers: number;
     totalComments: number;
-    totalUsers: number;
-    totalLikes: number;
-    avgLikesPerPost: number;
-    avgCommentsPerPost: number;
+    avgLikes: number;
+    postsGrowthRate: number;
+    usersGrowthRate: number;
 }
 
 export interface PostListParams {

--- a/src/lib/api/useCategories.ts
+++ b/src/lib/api/useCategories.ts
@@ -11,8 +11,17 @@ export const useCategories = () => {
   return useQuery({
     queryKey: ['community', 'categories'],
     queryFn: async (): Promise<Category[]> => {
-      const response = await apiCall<{ success: boolean; data: Category[] }>('/community/categories');
-      return response.data;
+      const response = await apiCall<Category[] | { success: boolean; data: Category[] }>('/community/categories');
+
+      if (Array.isArray(response)) {
+        return response;
+      }
+
+      if (response && typeof response === 'object' && 'data' in response) {
+        return response.data ?? [];
+      }
+
+      return [];
     },
     staleTime: 10 * 60 * 1000, // 10분
     gcTime: 30 * 60 * 1000, // 30분


### PR DESCRIPTION
## Summary
- 커뮤니티 메인 화면의 통계, 탭, 글쓰기 흐름을 실시간 API 데이터와 연결하고 통계 카드/피드백 UI를 정비했습니다.
- 커뮤니티 글 작성/수정 폼과 공용 PostForm에서 카테고리를 API로 불러오도록 바꾸고 로딩·에러 대응을 추가했습니다.
- 카테고리/커뮤니티 통계 타입과 훅의 응답 파싱을 실제 서버 스키마와 맞춰 신뢰성을 높였습니다.

## Testing
- npm run lint *(실패: 환경에 @typescript-eslint/parser 패키지가 설치되지 않아 ESLint 실행 불가)*

------
https://chatgpt.com/codex/tasks/task_b_68ce816e53a883269890688bd33593e9