### PR TITLE
fix: correct community stats endpoint

### DIFF
--- a/src/features/community/hooks/__tests__/useCommunityStats.test.ts
+++ b/src/features/community/hooks/__tests__/useCommunityStats.test.ts
@@ -1,0 +1,57 @@
+import { normalizeCommunityStatsResponse } from '../useCommunity';
+
+const baseResponse = {
+    totalPosts: 12,
+    activeUsers: 7,
+    totalComments: 32,
+    avgLikes: 4,
+    postsGrowthRate: 15,
+    usersGrowthRate: -3,
+};
+
+describe('normalizeCommunityStatsResponse', () => {
+    it('returns numeric stats from a direct response object', () => {
+        const result = normalizeCommunityStatsResponse(baseResponse);
+
+        expect(result).toEqual({
+            totalPosts: 12,
+            activeUsers: 7,
+            totalComments: 32,
+            avgLikes: 4,
+            postsGrowthRate: 15,
+            usersGrowthRate: -3,
+        });
+    });
+
+    it('unwraps nested data payloads', () => {
+        const result = normalizeCommunityStatsResponse({ success: true, data: baseResponse });
+
+        expect(result).toEqual({
+            totalPosts: 12,
+            activeUsers: 7,
+            totalComments: 32,
+            avgLikes: 4,
+            postsGrowthRate: 15,
+            usersGrowthRate: -3,
+        });
+    });
+
+    it('coerces non-numeric values and fills missing fields with zero', () => {
+        const result = normalizeCommunityStatsResponse({
+            data: {
+                totalPosts: '25',
+                activeUsers: 'not-a-number',
+                avgLikes: undefined,
+            },
+        });
+
+        expect(result).toEqual({
+            totalPosts: 25,
+            activeUsers: 0,
+            totalComments: 0,
+            avgLikes: 0,
+            postsGrowthRate: 0,
+            usersGrowthRate: 0,
+        });
+    });
+});

--- a/src/services/__tests__/communityStatsApi.test.ts
+++ b/src/services/__tests__/communityStatsApi.test.ts
@@ -1,0 +1,17 @@
+import { communityPostAPI, statsAPI } from '../api';
+
+describe('communityPostAPI.getStats', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('delegates to statsAPI.getCommunityStats to avoid missing endpoints', async () => {
+        const mockStats = { totalPosts: 10 } as any;
+        const spy = jest.spyOn(statsAPI, 'getCommunityStats').mockResolvedValue(mockStats);
+
+        const result = await communityPostAPI.getStats();
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(result).toBe(mockStats);
+    });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1053,7 +1053,7 @@ export const communityPostAPI = {
     getCategories: () => apiCall('/community/categories'),
 
     // 통계 조회
-    getStats: () => apiCall('/community/stats'),
+    getStats: () => statsAPI.getCommunityStats(),
 
     // 내 게시글 조회
     getMyPosts: (params?: any) => {


### PR DESCRIPTION
## Summary
- route community stats requests through the shared stats API helper so the screen no longer hits the missing /community/stats endpoint
- normalize the community stats hook so it safely unwraps nested { success, data } responses and coerces numeric fields
- add unit coverage for both the normalization helper and the delegated API call to guard against regressions

## Testing
- npm test -- --runTestsByPath src/services/__tests__/communityStatsApi.test.ts src/features/community/hooks/__tests__/useCommunityStats.test.ts *(fails: Jest binary unavailable because npm install cannot download the dotenv package from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce8b4526e48326b1c247c27782e512