### PR TITLE
fix: harden token refresh sanitization

### DIFF
--- a/src/features/auth/services/__tests__/authService.test.ts
+++ b/src/features/auth/services/__tests__/authService.test.ts
@@ -1,0 +1,56 @@
+import { storeTokens, sanitizeToken } from '../authService';
+
+describe('authService helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('sanitizeToken', () => {
+    it('returns trimmed token when value is valid', () => {
+      expect(sanitizeToken('  valid-token  ')).toBe('valid-token');
+    });
+
+    it('returns null for blank-like values', () => {
+      expect(sanitizeToken('')).toBeNull();
+      expect(sanitizeToken('   ')).toBeNull();
+      expect(sanitizeToken('undefined')).toBeNull();
+      expect(sanitizeToken('null')).toBeNull();
+      expect(sanitizeToken(null)).toBeNull();
+    });
+  });
+
+  describe('storeTokens', () => {
+    it('prefers sanitized accessToken but falls back to token when needed', () => {
+      const { accessToken, refreshToken } = storeTokens('   ', '  undefined  ', 'fallback-token');
+
+      expect(accessToken).toBe('fallback-token');
+      expect(refreshToken).toBeNull();
+      expect(localStorage.getItem('authToken')).toBe('fallback-token');
+      expect(localStorage.getItem('accessToken')).toBe('fallback-token');
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+
+    it('clears tokens when no valid value is provided', () => {
+      localStorage.setItem('authToken', 'stale');
+      localStorage.setItem('accessToken', 'stale');
+      localStorage.setItem('refreshToken', 'stale');
+
+      const { accessToken, refreshToken } = storeTokens(undefined, undefined, undefined);
+
+      expect(accessToken).toBeNull();
+      expect(refreshToken).toBeNull();
+      expect(localStorage.getItem('authToken')).toBeNull();
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+
+    it("does not leave the string 'undefined' in storage", () => {
+      const { accessToken } = storeTokens('undefined', 'undefined', 'undefined');
+
+      expect(accessToken).toBeNull();
+      expect(localStorage.getItem('authToken')).toBeNull();
+      expect(localStorage.getItem('accessToken')).toBeNull();
+      expect(localStorage.getItem('refreshToken')).toBeNull();
+    });
+  });
+});

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -13,7 +13,7 @@ type StoredTokens = {
     refreshToken: string | null;
 };
 
-const sanitizeToken = (token?: string | null): string | null => {
+export const sanitizeToken = (token?: string | null): string | null => {
     if (!token) return null;
 
     const trimmed = token.trim();
@@ -24,8 +24,19 @@ const sanitizeToken = (token?: string | null): string | null => {
     return trimmed;
 };
 
-const storeTokens = (accessToken?: string | null, refreshToken?: string | null): StoredTokens => {
-    const sanitizedAccessToken = sanitizeToken(accessToken);
+export const selectValidAccessToken = (
+    accessToken?: string | null,
+    fallbackToken?: string | null,
+): string | null => {
+    return sanitizeToken(accessToken) ?? sanitizeToken(fallbackToken);
+};
+
+export const storeTokens = (
+    accessToken?: string | null,
+    refreshToken?: string | null,
+    fallbackToken?: string | null,
+): StoredTokens => {
+    const sanitizedAccessToken = selectValidAccessToken(accessToken, fallbackToken);
     const sanitizedRefreshToken = sanitizeToken(refreshToken);
 
     if (!sanitizedAccessToken) {
@@ -108,16 +119,21 @@ class AuthService {
             throw new Error(response.error || '로그인에 실패했습니다');
         }
 
-        const rawAccessToken = response.data.accessToken ?? response.data.token ?? null;
-        const rawRefreshToken = response.data.refreshToken ?? null;
+        const storedTokens = storeTokens(
+            response.data.accessToken,
+            response.data.refreshToken,
+            response.data.token,
+        );
 
         // 토큰을 localStorage에 저장
         console.log('🔐 Login Success - Storing tokens:', {
-            accessToken: rawAccessToken ? `${rawAccessToken.substring(0, 20)}...` : 'null',
-            refreshToken: rawRefreshToken ? `${rawRefreshToken.substring(0, 20)}...` : 'null'
+            accessToken: storedTokens.accessToken
+                ? `${storedTokens.accessToken.substring(0, 20)}...`
+                : 'null',
+            refreshToken: storedTokens.refreshToken
+                ? `${storedTokens.refreshToken.substring(0, 20)}...`
+                : 'null',
         });
-
-        const storedTokens = storeTokens(rawAccessToken, rawRefreshToken);
 
         if (!storedTokens.accessToken) {
             throw new Error('유효한 로그인 토큰을 받지 못했습니다');
@@ -154,9 +170,11 @@ class AuthService {
             throw new Error(response.error || '회원가입에 실패했습니다');
         }
 
-        const rawAccessToken = response.data.accessToken ?? response.data.token ?? null;
-        const rawRefreshToken = response.data.refreshToken ?? null;
-        const storedTokens = storeTokens(rawAccessToken, rawRefreshToken);
+        const storedTokens = storeTokens(
+            response.data.accessToken,
+            response.data.refreshToken,
+            response.data.token,
+        );
 
         if (!storedTokens.accessToken) {
             throw new Error('유효한 인증 토큰을 받지 못했습니다');
@@ -217,9 +235,11 @@ class AuthService {
             throw new Error(response.error || '토큰 갱신에 실패했습니다');
         }
 
-        const rawAccessToken = response.data.accessToken ?? response.data.token ?? null;
-        const rawRefreshToken = response.data.refreshToken ?? null;
-        const storedTokens = storeTokens(rawAccessToken, rawRefreshToken);
+        const storedTokens = storeTokens(
+            response.data.accessToken,
+            response.data.refreshToken,
+            response.data.token,
+        );
 
         if (!storedTokens.accessToken) {
             throw new Error('토큰 갱신에 실패했습니다 (유효한 토큰 없음)');


### PR DESCRIPTION
## Summary
- export reusable token sanitization helpers from the auth service and reuse them during login, signup, and refresh flows
- update the API client's interceptors to sanitize refreshed tokens, fall back to `token`, and abort gracefully when no valid token is returned
- add unit coverage ensuring token helpers never persist blank or `'undefined'` values to localStorage

## Testing
- `npm test -- --runInBand` *(fails: jest binary missing because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce8b48a5788326995b94e886946d87