### PR TITLE
fix: sanitize token persistence across auth flows

### DIFF
--- a/src/features/auth/services/tokenStorage.ts
+++ b/src/features/auth/services/tokenStorage.ts
@@ -1,0 +1,171 @@
+const AUTH_TOKEN_KEY = 'authToken';
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+const getStorage = (): Storage | null => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+    }
+
+    return window.localStorage;
+};
+
+export const sanitizeToken = (token?: string | null): string | null => {
+    if (typeof token !== 'string') {
+        return null;
+    }
+
+    const trimmed = token.trim();
+
+    if (!trimmed || trimmed === 'undefined' || trimmed === 'null') {
+        return null;
+    }
+
+    return trimmed;
+};
+
+const pickValidToken = (...candidates: Array<string | null | undefined>): string | null => {
+    for (const candidate of candidates) {
+        const sanitized = sanitizeToken(candidate);
+        if (sanitized) {
+            return sanitized;
+        }
+    }
+
+    return null;
+};
+
+export const previewToken = (token?: string | null): string => {
+    const sanitized = sanitizeToken(token);
+    if (!sanitized) {
+        return 'null';
+    }
+
+    const visibleLength = 20;
+    return sanitized.length > visibleLength
+        ? `${sanitized.substring(0, visibleLength)}...`
+        : sanitized;
+};
+
+export const clearTokens = (): void => {
+    const storage = getStorage();
+    if (!storage) {
+        return;
+    }
+
+    storage.removeItem(AUTH_TOKEN_KEY);
+    storage.removeItem(ACCESS_TOKEN_KEY);
+    storage.removeItem(REFRESH_TOKEN_KEY);
+};
+
+export const cleanInvalidTokens = (): void => {
+    const storage = getStorage();
+    if (!storage) {
+        return;
+    }
+
+    const entries: Array<[key: string, value: string | null]> = [
+        [AUTH_TOKEN_KEY, storage.getItem(AUTH_TOKEN_KEY)],
+        [ACCESS_TOKEN_KEY, storage.getItem(ACCESS_TOKEN_KEY)],
+        [REFRESH_TOKEN_KEY, storage.getItem(REFRESH_TOKEN_KEY)],
+    ];
+
+    entries.forEach(([key, value]) => {
+        if (!sanitizeToken(value)) {
+            storage.removeItem(key);
+        }
+    });
+};
+
+export const persistTokens = ({
+    accessToken,
+    refreshToken,
+    fallbackToken,
+}: {
+    accessToken?: string | null;
+    refreshToken?: string | null;
+    fallbackToken?: string | null;
+}): { accessToken: string | null; refreshToken: string | null } => {
+    const storage = getStorage();
+    if (!storage) {
+        return { accessToken: null, refreshToken: null };
+    }
+
+    const primaryToken = pickValidToken(accessToken, fallbackToken);
+    const sanitizedRefreshToken = pickValidToken(refreshToken);
+
+    if (!primaryToken) {
+        clearTokens();
+        return { accessToken: null, refreshToken: null };
+    }
+
+    storage.setItem(AUTH_TOKEN_KEY, primaryToken);
+    storage.setItem(ACCESS_TOKEN_KEY, primaryToken);
+
+    if (sanitizedRefreshToken) {
+        storage.setItem(REFRESH_TOKEN_KEY, sanitizedRefreshToken);
+    } else {
+        storage.removeItem(REFRESH_TOKEN_KEY);
+    }
+
+    return {
+        accessToken: primaryToken,
+        refreshToken: sanitizedRefreshToken,
+    };
+};
+
+export const getStoredAccessToken = (): string | null => {
+    const storage = getStorage();
+    if (!storage) {
+        return null;
+    }
+
+    return pickValidToken(storage.getItem(AUTH_TOKEN_KEY), storage.getItem(ACCESS_TOKEN_KEY));
+};
+
+export const getStoredRefreshToken = (): string | null => {
+    const storage = getStorage();
+    if (!storage) {
+        return null;
+    }
+
+    return pickValidToken(storage.getItem(REFRESH_TOKEN_KEY));
+};
+
+export const getTokenSnapshot = (): {
+    keys: string[];
+    authToken: string | null;
+    accessToken: string | null;
+    refreshToken: string | null;
+} => {
+    const storage = getStorage();
+    if (!storage) {
+        return {
+            keys: [],
+            authToken: null,
+            accessToken: null,
+            refreshToken: null,
+        };
+    }
+
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (key) {
+            keys.push(key);
+        }
+    }
+
+    return {
+        keys,
+        authToken: storage.getItem(AUTH_TOKEN_KEY),
+        accessToken: storage.getItem(ACCESS_TOKEN_KEY),
+        refreshToken: storage.getItem(REFRESH_TOKEN_KEY),
+    };
+};
+
+export {
+    AUTH_TOKEN_KEY,
+    ACCESS_TOKEN_KEY,
+    REFRESH_TOKEN_KEY,
+};

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -26,12 +26,14 @@ export interface SignupData {
 export interface AuthResponse {
     user: User;
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface RefreshTokenResponse {
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface PasswordResetRequest {

--- a/src/features/community/types/index.ts
+++ b/src/features/community/types/index.ts
@@ -58,11 +58,11 @@ export interface CommunityCategory {
 
 export interface CommunityStats {
     totalPosts: number;
+    activeUsers: number;
     totalComments: number;
-    totalUsers: number;
-    totalLikes: number;
-    avgLikesPerPost: number;
-    avgCommentsPerPost: number;
+    avgLikes: number;
+    postsGrowthRate: number;
+    usersGrowthRate: number;
 }
 
 export interface PostListParams {

--- a/src/lib/api/useCategories.ts
+++ b/src/lib/api/useCategories.ts
@@ -11,8 +11,17 @@ export const useCategories = () => {
   return useQuery({
     queryKey: ['community', 'categories'],
     queryFn: async (): Promise<Category[]> => {
-      const response = await apiCall<{ success: boolean; data: Category[] }>('/community/categories');
-      return response.data;
+      const response = await apiCall<Category[] | { success: boolean; data: Category[] }>('/community/categories');
+
+      if (Array.isArray(response)) {
+        return response;
+      }
+
+      if (response && typeof response === 'object' && 'data' in response) {
+        return response.data ?? [];
+      }
+
+      return [];
     },
     staleTime: 10 * 60 * 1000, // 10분
     gcTime: 30 * 60 * 1000, // 30분


### PR DESCRIPTION
## Summary
- broaden API response extraction to retain payloads without a `data` wrapper so list endpoints like community posts stop returning `null`
- harden community API client helpers with a shared `unwrapData` utility and stricter guards so list/detail/comment calls gracefully handle varied payload shapes
- point community stats fetching at `/stats/community` to match the server route
- centralize token sanitization and persistence so login, signup, refresh, and Axios interceptors all fall back to legacy `token` fields without leaking `'undefined'`/`'null'` into storage

## Testing
- npm run lint *(fails: `@typescript-eslint/parser` is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce816e53a883269890688bd33593e9