### PR TITLE
fix: normalize api base url paths

### DIFF
--- a/src/lib/config/__tests__/env.test.ts
+++ b/src/lib/config/__tests__/env.test.ts
@@ -1,0 +1,67 @@
+const importEnvModule = async () => {
+  jest.resetModules();
+  return import('../env');
+};
+
+const originalViteApiBaseUrl = process.env.VITE_API_BASE_URL;
+const originalReactAppApiUrl = process.env.REACT_APP_API_URL;
+
+afterEach(() => {
+  if (typeof originalViteApiBaseUrl === 'undefined') {
+    delete process.env.VITE_API_BASE_URL;
+  } else {
+    process.env.VITE_API_BASE_URL = originalViteApiBaseUrl;
+  }
+
+  if (typeof originalReactAppApiUrl === 'undefined') {
+    delete process.env.REACT_APP_API_URL;
+  } else {
+    process.env.REACT_APP_API_URL = originalReactAppApiUrl;
+  }
+});
+
+describe('ensureApiPath', () => {
+  it('removes trailing slashes from absolute paths', async () => {
+    const { ensureApiPath } = await importEnvModule();
+    expect(ensureApiPath('https://host/api/')).toBe('https://host/api');
+  });
+
+  it('leaves absolute paths without trailing slashes unchanged', async () => {
+    const { ensureApiPath } = await importEnvModule();
+    expect(ensureApiPath('https://host/api')).toBe('https://host/api');
+  });
+
+  it('removes trailing slashes from relative paths', async () => {
+    const { ensureApiPath } = await importEnvModule();
+    expect(ensureApiPath('/api/')).toBe('/api');
+  });
+
+  it('leaves relative paths without trailing slashes unchanged', async () => {
+    const { ensureApiPath } = await importEnvModule();
+    expect(ensureApiPath('/api')).toBe('/api');
+  });
+});
+
+describe('resolveApiBaseUrl', () => {
+  it('normalizes trailing slashes from environment variables', async () => {
+    process.env.VITE_API_BASE_URL = 'https://host/api/';
+    const { resolveApiBaseUrl } = await importEnvModule();
+
+    expect(resolveApiBaseUrl()).toBe('https://host/api');
+  });
+
+  it('handles relative environment paths without trailing slash', async () => {
+    process.env.VITE_API_BASE_URL = '/api/';
+    const { resolveApiBaseUrl } = await importEnvModule();
+
+    expect(resolveApiBaseUrl()).toBe('/api');
+  });
+
+  it('falls back to the default API path when environment variables are absent', async () => {
+    delete process.env.VITE_API_BASE_URL;
+    delete process.env.REACT_APP_API_URL;
+    const { resolveApiBaseUrl } = await importEnvModule();
+
+    expect(resolveApiBaseUrl()).toBe('http://localhost:5000/api');
+  });
+});

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -36,14 +36,27 @@ export const isLocalEnvironment = (): boolean => {
   return window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
 };
 
+export const ensureApiPath = (path: string): string => {
+  if (!path) {
+    return path;
+  }
+
+  if (path === '/') {
+    return path;
+  }
+
+  return path.replace(/\/+$/, '');
+};
+
 export const resolveApiBaseUrl = (): string => {
   const fallback = isLocalEnvironment()
     ? 'http://localhost:5000/api'
     : 'https://collaboreumplatform-production.up.railway.app/api';
 
-  return (
+  const baseUrl =
     getEnvVar('VITE_API_BASE_URL') ??
     getEnvVar('REACT_APP_API_URL') ??
-    fallback
-  );
+    fallback;
+
+  return ensureApiPath(baseUrl);
 };


### PR DESCRIPTION
## Summary
- ensure API base URLs drop trailing slashes for absolute and relative paths
- cover the normalization helper and resolver with focused Jest tests

## Testing
- npm test -- src/lib/config/__tests__/env.test.ts *(fails: local Jest binary unavailable because npm install is blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ce95e3e5e88326b445cdca4311082d