### PR TITLE
fix: harden auth token handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,7 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <Router>
-            <div className='relative min-h-screen bg-background'>
-              {/* 상단 흐림 → 중앙 짙음 그라데이션 */}
-              <div className='bg-gradient-top-to-center-strong pointer-events-none absolute inset-0'></div>
+            <div className='min-h-screen bg-background'>
               <Toast />
               <AppRoutes />
             </div>

--- a/src/components/CommunityPostForm.tsx
+++ b/src/components/CommunityPostForm.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { resolveApiBaseUrl } from '@/lib/config/env';
+import { getStoredAccessToken } from '@/features/auth/services/tokenStorage';
 import { Button } from '../shared/ui/Button';
 import { Input } from './ui/input';
 import { Textarea } from './ui/textarea';
@@ -113,6 +114,13 @@ export const CommunityPostForm: React.FC<CommunityPostFormProps> = ({
       return;
     }
 
+    const token = getStoredAccessToken();
+
+    if (!token) {
+      setError('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
+      return;
+    }
+
     setIsSubmitting(true);
     setError('');
 
@@ -127,7 +135,6 @@ export const CommunityPostForm: React.FC<CommunityPostFormProps> = ({
         });
 
         // 이미지 업로드는 FormData를 직접 fetch로 처리
-        const token = localStorage.getItem('authToken');
         const API_BASE_URL = resolveApiBaseUrl();
         const imageResponse = await fetch(`${API_BASE_URL}/upload/images`, {
           method: 'POST',

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -57,8 +57,8 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
     selectedCategory === '전체'
       ? weeklyNewcomers
       : weeklyNewcomers.filter(
-          (artist: any) => artist.category === selectedCategory,
-        );
+        (artist: any) => artist.category === selectedCategory,
+      );
 
   const nextSlide = () => {
     setCurrentIndex(prev => (prev + 1) % filteredNewcomers.length);
@@ -195,11 +195,10 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
                     setSelectedCategory(category);
                     setCurrentIndex(0);
                   }}
-                  className={`cursor-pointer rounded-xl px-6 py-3 font-medium transition-all ${
-                    selectedCategory === category
+                  className={`cursor-pointer rounded-xl px-6 py-3 font-medium transition-all ${selectedCategory === category
                     ? 'shadow-apple bg-primary text-primary-foreground'
                     : 'hover:bg-secondary/50 text-muted-foreground hover:text-foreground'
-                  }`}
+                    }`}
                 >
                   {category}
                 </button>
@@ -230,15 +229,14 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
                         />
                         <div className='absolute inset-0 bg-gradient-to-t from-black/60 to-transparent' />
                         <Badge
-                          className={`absolute left-4 top-4 rounded-xl font-medium ${
-                            artist.category === '음악'
+                          className={`absolute left-4 top-4 rounded-xl font-medium ${artist.category === '음악'
                             ? 'bg-primary text-primary-foreground'
                             : artist.category === '미술'
                               ? 'bg-chart-5 text-white'
                               : artist.category === '문학'
                                 ? 'bg-chart-2 text-white'
                                 : 'bg-destructive text-white'
-                          }`}
+                            }`}
                         >
                           {artist.category}
                         </Badge>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -100,8 +100,6 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
         {/* Sophisticated Background */}
         <div className='absolute inset-0'>
           <div className='via-secondary/20 to-muted/30 absolute inset-0 bg-gradient-to-br from-background'></div>
-          {/* 상단 흐림 → 중앙 짙음 그라데이션 */}
-          <div className='bg-gradient-top-to-center-strong absolute inset-0'></div>
           {/* Animated Background Elements */}
           <div className='bg-primary/10 animate-float absolute left-1/4 top-1/4 h-72 w-72 rounded-full blur-3xl'></div>
           <div
@@ -199,8 +197,8 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
                   }}
                   className={`cursor-pointer rounded-xl px-6 py-3 font-medium transition-all ${
                     selectedCategory === category
-                      ? 'shadow-apple bg-primary text-primary-foreground'
-                      : 'hover:bg-secondary/50 text-muted-foreground hover:text-foreground'
+                    ? 'shadow-apple bg-primary text-primary-foreground'
+                    : 'hover:bg-secondary/50 text-muted-foreground hover:text-foreground'
                   }`}
                 >
                   {category}
@@ -234,12 +232,12 @@ export function HeroSection({ onViewArtistCommunity }: HeroSectionProps) {
                         <Badge
                           className={`absolute left-4 top-4 rounded-xl font-medium ${
                             artist.category === '음악'
-                              ? 'bg-primary text-primary-foreground'
-                              : artist.category === '미술'
-                                ? 'bg-chart-5 text-white'
-                                : artist.category === '문학'
-                                  ? 'bg-chart-2 text-white'
-                                  : 'bg-destructive text-white'
+                            ? 'bg-primary text-primary-foreground'
+                            : artist.category === '미술'
+                              ? 'bg-chart-5 text-white'
+                              : artist.category === '문학'
+                                ? 'bg-chart-2 text-white'
+                                : 'bg-destructive text-white'
                           }`}
                         >
                           {artist.category}

--- a/src/features/auth/services/__tests__/tokenStorage.test.ts
+++ b/src/features/auth/services/__tests__/tokenStorage.test.ts
@@ -1,0 +1,126 @@
+import {
+    sanitizeToken,
+    persistTokens,
+    clearTokens,
+    getStoredAccessToken,
+    resolveAuthTokenCandidates,
+    AUTH_TOKEN_KEY,
+} from '../tokenStorage';
+
+const SAMPLE_JWT = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+
+describe('tokenStorage helpers', () => {
+    beforeEach(() => {
+        clearTokens();
+        localStorage.clear();
+    });
+
+    describe('sanitizeToken', () => {
+        it('returns null for non-string input', () => {
+            expect(sanitizeToken(undefined)).toBeNull();
+            expect(sanitizeToken(null)).toBeNull();
+        });
+
+        it('filters out bearer prefixes and undefined noise', () => {
+            const noisy = `Bearer undefined${SAMPLE_JWT}`;
+            expect(sanitizeToken(noisy)).toBe(SAMPLE_JWT);
+        });
+
+        it('filters quoted tokens', () => {
+            const quoted = `"${SAMPLE_JWT}"`;
+            expect(sanitizeToken(quoted)).toBe(SAMPLE_JWT);
+        });
+
+        it('removes explicit null-like strings', () => {
+            expect(sanitizeToken('null')).toBeNull();
+            expect(sanitizeToken('undefined')).toBeNull();
+        });
+
+        it('keeps already clean tokens untouched', () => {
+            expect(sanitizeToken(SAMPLE_JWT)).toBe(SAMPLE_JWT);
+        });
+    });
+
+    describe('persistTokens', () => {
+        it('stores sanitized fallback tokens when access token is missing', () => {
+            const fallbackToken = `undefined${SAMPLE_JWT}`;
+            const result = persistTokens({ fallbackToken });
+
+            expect(result.accessToken).toBe(SAMPLE_JWT);
+            expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBe(SAMPLE_JWT);
+        });
+
+        it('clears storage when sanitized token is empty', () => {
+            localStorage.setItem(AUTH_TOKEN_KEY, 'stale');
+            const result = persistTokens({ accessToken: 'null' });
+
+            expect(result.accessToken).toBeNull();
+            expect(localStorage.getItem(AUTH_TOKEN_KEY)).toBeNull();
+        });
+    });
+
+    describe('getStoredAccessToken', () => {
+        it('returns sanitized token from storage', () => {
+            localStorage.setItem(AUTH_TOKEN_KEY, `Bearer undefined${SAMPLE_JWT}`);
+            expect(getStoredAccessToken()).toBe(SAMPLE_JWT);
+        });
+    });
+
+    describe('resolveAuthTokenCandidates', () => {
+        it('extracts tokens from nested data objects', () => {
+            const response = {
+                success: true,
+                data: {
+                    accessToken: SAMPLE_JWT,
+                    refreshToken: `${SAMPLE_JWT}.refresh`,
+                },
+            };
+
+            expect(resolveAuthTokenCandidates(response)).toEqual({
+                accessToken: SAMPLE_JWT,
+                fallbackToken: SAMPLE_JWT,
+                refreshToken: `${SAMPLE_JWT}.refresh`,
+            });
+        });
+
+        it('falls back to legacy token fields when accessToken is missing', () => {
+            const response = {
+                success: true,
+                data: {
+                    token: SAMPLE_JWT,
+                },
+            };
+
+            expect(resolveAuthTokenCandidates(response)).toEqual({
+                accessToken: null,
+                fallbackToken: SAMPLE_JWT,
+                refreshToken: null,
+            });
+        });
+
+        it('supports deeply nested payloads', () => {
+            const response = {
+                result: {
+                    tokens: {
+                        jwtToken: SAMPLE_JWT,
+                        refresh_token: `${SAMPLE_JWT}.refresh`,
+                    },
+                },
+            };
+
+            expect(resolveAuthTokenCandidates(response)).toEqual({
+                accessToken: SAMPLE_JWT,
+                fallbackToken: SAMPLE_JWT,
+                refreshToken: `${SAMPLE_JWT}.refresh`,
+            });
+        });
+
+        it('returns null tokens when no candidates exist', () => {
+            expect(resolveAuthTokenCandidates({ success: false })).toEqual({
+                accessToken: null,
+                fallbackToken: null,
+                refreshToken: null,
+            });
+        });
+    });
+});

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -9,9 +9,22 @@ const ACCESS_TOKEN_KEY = 'accessToken';
 const REFRESH_TOKEN_KEY = 'refreshToken';
 
 const storeTokens = (accessToken: string, refreshToken: string) => {
+    // 유효한 토큰인지 확인
+    if (!accessToken || accessToken === 'undefined' || accessToken === 'null') {
+        console.error('❌ Invalid accessToken:', accessToken);
+        return;
+    }
+    
+    if (!refreshToken || refreshToken === 'undefined' || refreshToken === 'null') {
+        console.error('❌ Invalid refreshToken:', refreshToken);
+        return;
+    }
+    
     localStorage.setItem(AUTH_TOKEN_KEY, accessToken);
     localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
     localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    
+    console.log('✅ Tokens stored successfully');
 };
 
 const clearTokens = () => {
@@ -20,12 +33,38 @@ const clearTokens = () => {
     localStorage.removeItem(REFRESH_TOKEN_KEY);
 };
 
+const cleanInvalidTokens = () => {
+    const authToken = localStorage.getItem(AUTH_TOKEN_KEY);
+    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    
+    if (authToken === 'undefined' || authToken === 'null') {
+        localStorage.removeItem(AUTH_TOKEN_KEY);
+        console.log('🧹 Cleaned invalid authToken');
+    }
+    
+    if (accessToken === 'undefined' || accessToken === 'null') {
+        localStorage.removeItem(ACCESS_TOKEN_KEY);
+        console.log('🧹 Cleaned invalid accessToken');
+    }
+    
+    if (refreshToken === 'undefined' || refreshToken === 'null') {
+        localStorage.removeItem(REFRESH_TOKEN_KEY);
+        console.log('🧹 Cleaned invalid refreshToken');
+    }
+};
+
 const getStoredAccessToken = () => {
     return localStorage.getItem(AUTH_TOKEN_KEY) ?? localStorage.getItem(ACCESS_TOKEN_KEY);
 };
 
 class AuthService {
     private baseUrl = `${API_BASE_URL}/auth`;
+    
+    constructor() {
+        // 앱 시작 시 잘못된 토큰들 정리
+        cleanInvalidTokens();
+    }
 
     /**
      * 로그인
@@ -48,9 +87,9 @@ class AuthService {
             accessToken: response.data.accessToken ? `${response.data.accessToken.substring(0, 20)}...` : 'null',
             refreshToken: response.data.refreshToken ? `${response.data.refreshToken.substring(0, 20)}...` : 'null'
         });
-        
+
         storeTokens(response.data.accessToken, response.data.refreshToken);
-        
+
         // 저장 후 확인
         console.log('🔐 Tokens stored - Verification:', {
             authToken: localStorage.getItem(AUTH_TOKEN_KEY) ? `${localStorage.getItem(AUTH_TOKEN_KEY)!.substring(0, 20)}...` : 'null',

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -44,7 +44,19 @@ class AuthService {
         }
 
         // 토큰을 localStorage에 저장
+        console.log('🔐 Login Success - Storing tokens:', {
+            accessToken: response.data.accessToken ? `${response.data.accessToken.substring(0, 20)}...` : 'null',
+            refreshToken: response.data.refreshToken ? `${response.data.refreshToken.substring(0, 20)}...` : 'null'
+        });
+        
         storeTokens(response.data.accessToken, response.data.refreshToken);
+        
+        // 저장 후 확인
+        console.log('🔐 Tokens stored - Verification:', {
+            authToken: localStorage.getItem(AUTH_TOKEN_KEY) ? `${localStorage.getItem(AUTH_TOKEN_KEY)!.substring(0, 20)}...` : 'null',
+            accessToken: localStorage.getItem(ACCESS_TOKEN_KEY) ? `${localStorage.getItem(ACCESS_TOKEN_KEY)!.substring(0, 20)}...` : 'null',
+            refreshToken: localStorage.getItem(REFRESH_TOKEN_KEY) ? `${localStorage.getItem(REFRESH_TOKEN_KEY)!.substring(0, 20)}...` : 'null'
+        });
 
         return response.data;
     }

--- a/src/features/auth/services/authService.ts
+++ b/src/features/auth/services/authService.ts
@@ -1,62 +1,18 @@
 import { resolveApiBaseUrl } from '@/lib/config/env';
+import {
+    cleanInvalidTokens,
+    clearTokens,
+    getStoredAccessToken,
+    getStoredRefreshToken,
+    persistTokens,
+    previewToken,
+    resolveAuthTokenCandidates,
+} from '@/features/auth/services/tokenStorage';
 import { AuthResponse, RefreshTokenResponse, LoginCredentials, SignupData, PasswordResetRequest, PasswordReset } from '../types';
 import { ApiResponse } from '../../../shared/types';
 // import { fetch } from '../../../utils/fetch';
 
 const API_BASE_URL = resolveApiBaseUrl();
-const AUTH_TOKEN_KEY = 'authToken';
-const ACCESS_TOKEN_KEY = 'accessToken';
-const REFRESH_TOKEN_KEY = 'refreshToken';
-
-const storeTokens = (accessToken: string, refreshToken: string) => {
-    // 유효한 토큰인지 확인
-    if (!accessToken || accessToken === 'undefined' || accessToken === 'null') {
-        console.error('❌ Invalid accessToken:', accessToken);
-        return;
-    }
-    
-    if (!refreshToken || refreshToken === 'undefined' || refreshToken === 'null') {
-        console.error('❌ Invalid refreshToken:', refreshToken);
-        return;
-    }
-    
-    localStorage.setItem(AUTH_TOKEN_KEY, accessToken);
-    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
-    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
-    
-    console.log('✅ Tokens stored successfully');
-};
-
-const clearTokens = () => {
-    localStorage.removeItem(AUTH_TOKEN_KEY);
-    localStorage.removeItem(ACCESS_TOKEN_KEY);
-    localStorage.removeItem(REFRESH_TOKEN_KEY);
-};
-
-const cleanInvalidTokens = () => {
-    const authToken = localStorage.getItem(AUTH_TOKEN_KEY);
-    const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
-    
-    if (authToken === 'undefined' || authToken === 'null') {
-        localStorage.removeItem(AUTH_TOKEN_KEY);
-        console.log('🧹 Cleaned invalid authToken');
-    }
-    
-    if (accessToken === 'undefined' || accessToken === 'null') {
-        localStorage.removeItem(ACCESS_TOKEN_KEY);
-        console.log('🧹 Cleaned invalid accessToken');
-    }
-    
-    if (refreshToken === 'undefined' || refreshToken === 'null') {
-        localStorage.removeItem(REFRESH_TOKEN_KEY);
-        console.log('🧹 Cleaned invalid refreshToken');
-    }
-};
-
-const getStoredAccessToken = () => {
-    return localStorage.getItem(AUTH_TOKEN_KEY) ?? localStorage.getItem(ACCESS_TOKEN_KEY);
-};
 
 class AuthService {
     private baseUrl = `${API_BASE_URL}/auth`;
@@ -82,22 +38,41 @@ class AuthService {
             throw new Error(response.error || '로그인에 실패했습니다');
         }
 
+        const tokenCandidates = resolveAuthTokenCandidates(response.data ?? response);
+        const candidateAccessToken = tokenCandidates.accessToken;
+        const fallbackToken = tokenCandidates.fallbackToken;
+        const rawRefreshToken = tokenCandidates.refreshToken;
+
         // 토큰을 localStorage에 저장
         console.log('🔐 Login Success - Storing tokens:', {
-            accessToken: response.data.accessToken ? `${response.data.accessToken.substring(0, 20)}...` : 'null',
-            refreshToken: response.data.refreshToken ? `${response.data.refreshToken.substring(0, 20)}...` : 'null'
+            accessToken: previewToken(candidateAccessToken),
+            fallbackToken: previewToken(fallbackToken),
+            refreshToken: previewToken(rawRefreshToken)
         });
 
-        storeTokens(response.data.accessToken, response.data.refreshToken);
+        const storedTokens = persistTokens({
+            accessToken: candidateAccessToken,
+            fallbackToken,
+            refreshToken: rawRefreshToken,
+        });
+
+        if (!storedTokens.accessToken) {
+            throw new Error('유효한 로그인 토큰을 받지 못했습니다');
+        }
 
         // 저장 후 확인
         console.log('🔐 Tokens stored - Verification:', {
-            authToken: localStorage.getItem(AUTH_TOKEN_KEY) ? `${localStorage.getItem(AUTH_TOKEN_KEY)!.substring(0, 20)}...` : 'null',
-            accessToken: localStorage.getItem(ACCESS_TOKEN_KEY) ? `${localStorage.getItem(ACCESS_TOKEN_KEY)!.substring(0, 20)}...` : 'null',
-            refreshToken: localStorage.getItem(REFRESH_TOKEN_KEY) ? `${localStorage.getItem(REFRESH_TOKEN_KEY)!.substring(0, 20)}...` : 'null'
+            authToken: previewToken(storedTokens.accessToken),
+            accessToken: previewToken(storedTokens.accessToken),
+            refreshToken: previewToken(storedTokens.refreshToken)
         });
 
-        return response.data;
+        return {
+            user: response.data.user,
+            accessToken: storedTokens.accessToken,
+            refreshToken: storedTokens.refreshToken,
+            token: fallbackToken ?? storedTokens.accessToken,
+        };
     }
 
     /**
@@ -116,25 +91,39 @@ class AuthService {
             throw new Error(response.error || '회원가입에 실패했습니다');
         }
 
-        // 토큰을 localStorage에 저장
-        storeTokens(response.data.accessToken, response.data.refreshToken);
+        const tokenCandidates = resolveAuthTokenCandidates(response.data ?? response);
+        const storedTokens = persistTokens({
+            accessToken: tokenCandidates.accessToken,
+            fallbackToken: tokenCandidates.fallbackToken,
+            refreshToken: tokenCandidates.refreshToken,
+        });
 
-        return response.data;
+        if (!storedTokens.accessToken) {
+            throw new Error('유효한 인증 토큰을 받지 못했습니다');
+        }
+
+        return {
+            user: response.data.user,
+            accessToken: storedTokens.accessToken,
+            refreshToken: storedTokens.refreshToken,
+            token: tokenCandidates.fallbackToken ?? storedTokens.accessToken,
+        };
     }
 
     /**
      * 로그아웃
      */
     async logout(): Promise<void> {
-        const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+        const refreshToken = getStoredRefreshToken();
+        const accessToken = getStoredAccessToken();
 
-        if (refreshToken) {
+        if (refreshToken && accessToken) {
             try {
                 await fetch(`${this.baseUrl}/logout`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
-                        'Authorization': `Bearer ${getStoredAccessToken()}`,
+                        'Authorization': `Bearer ${accessToken}`,
                     },
                     body: JSON.stringify({ refreshToken }),
                 });
@@ -151,7 +140,7 @@ class AuthService {
      * 토큰 갱신
      */
     async refreshToken(): Promise<RefreshTokenResponse> {
-        const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+        const refreshToken = getStoredRefreshToken();
 
         if (!refreshToken) {
             throw new Error('리프레시 토큰이 없습니다');
@@ -169,10 +158,22 @@ class AuthService {
             throw new Error(response.error || '토큰 갱신에 실패했습니다');
         }
 
-        // 새로운 토큰을 localStorage에 저장
-        storeTokens(response.data.accessToken, response.data.refreshToken);
+        const tokenCandidates = resolveAuthTokenCandidates(response.data ?? response);
+        const storedTokens = persistTokens({
+            accessToken: tokenCandidates.accessToken,
+            fallbackToken: tokenCandidates.fallbackToken,
+            refreshToken: tokenCandidates.refreshToken ?? refreshToken,
+        });
 
-        return response.data;
+        if (!storedTokens.accessToken) {
+            throw new Error('토큰 갱신에 실패했습니다 (유효한 토큰 없음)');
+        }
+
+        return {
+            accessToken: storedTokens.accessToken,
+            refreshToken: storedTokens.refreshToken,
+            token: tokenCandidates.fallbackToken ?? storedTokens.accessToken,
+        };
     }
 
     /**
@@ -314,7 +315,7 @@ class AuthService {
      * 현재 리프레시 토큰 가져오기
      */
     getRefreshToken(): string | null {
-        return localStorage.getItem(REFRESH_TOKEN_KEY);
+        return getStoredRefreshToken();
     }
 }
 

--- a/src/features/auth/services/tokenStorage.ts
+++ b/src/features/auth/services/tokenStorage.ts
@@ -1,0 +1,285 @@
+const AUTH_TOKEN_KEY = 'authToken';
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+type ObjectRecord = Record<string, unknown>;
+
+const COLLECTABLE_KEYS = new Set(['data', 'result', 'payload', 'tokens']);
+
+const isObjectLike = (value: unknown): value is ObjectRecord => {
+    return Boolean(value) && typeof value === 'object';
+};
+
+const collectCandidateObjects = (root: unknown, maxDepth = 4): ObjectRecord[] => {
+    if (!isObjectLike(root)) {
+        return [];
+    }
+
+    const queue: Array<{ node: ObjectRecord; depth: number }> = [{ node: root, depth: 0 }];
+    const seen = new Set<ObjectRecord>();
+    seen.add(root);
+    const collected: ObjectRecord[] = [];
+
+    while (queue.length > 0) {
+        const { node, depth } = queue.shift()!;
+        collected.push(node);
+
+        if (depth >= maxDepth) {
+            continue;
+        }
+
+        Object.entries(node).forEach(([key, value]) => {
+            if (!isObjectLike(value)) {
+                return;
+            }
+
+            if (seen.has(value as ObjectRecord)) {
+                return;
+            }
+
+            seen.add(value as ObjectRecord);
+            queue.push({ node: value as ObjectRecord, depth: COLLECTABLE_KEYS.has(key) ? depth : depth + 1 });
+        });
+    }
+
+    return collected;
+};
+
+const findFirstStringValue = (nodes: ObjectRecord[], keys: string[]): string | null => {
+    for (const node of nodes) {
+        for (const key of keys) {
+            if (!Object.prototype.hasOwnProperty.call(node, key)) {
+                continue;
+            }
+
+            const value = node[key];
+            if (typeof value === 'string') {
+                return value;
+            }
+        }
+    }
+
+    return null;
+};
+
+const ACCESS_TOKEN_KEYS = ['accessToken', 'access_token', 'access-token', 'jwt', 'jwtToken'];
+const REFRESH_TOKEN_KEYS = ['refreshToken', 'refresh_token', 'refresh-token', 'refreshJwt', 'refreshJwtToken'];
+const FALLBACK_TOKEN_KEYS = ['token', ...ACCESS_TOKEN_KEYS];
+
+const getStorage = (): Storage | null => {
+    if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+    }
+
+    return window.localStorage;
+};
+
+const stripLeadingNoise = (value: string): string => {
+    let result = value.trim();
+
+    if (!result) {
+        return '';
+    }
+
+    if (result.toLowerCase().startsWith('bearer')) {
+        result = result.slice('bearer'.length).trimStart();
+    }
+
+    result = result.replace(/^(?:undefined|null|"|')+/gi, '').trim();
+
+    return result;
+};
+
+export const sanitizeToken = (token?: string | null): string | null => {
+    if (typeof token !== 'string') {
+        return null;
+    }
+
+    const stripped = stripLeadingNoise(token);
+
+    if (!stripped || stripped.toLowerCase() === 'undefined' || stripped.toLowerCase() === 'null') {
+        return null;
+    }
+
+    return stripped;
+};
+
+const pickValidToken = (...candidates: Array<string | null | undefined>): string | null => {
+    for (const candidate of candidates) {
+        const sanitized = sanitizeToken(candidate);
+        if (sanitized) {
+            return sanitized;
+        }
+    }
+
+    return null;
+};
+
+export const resolveAuthTokenCandidates = (payload: unknown): {
+    accessToken: string | null;
+    fallbackToken: string | null;
+    refreshToken: string | null;
+} => {
+    if (typeof payload === 'string') {
+        return {
+            accessToken: payload,
+            fallbackToken: payload,
+            refreshToken: null,
+        };
+    }
+
+    const nodes = collectCandidateObjects(payload);
+
+    if (nodes.length === 0) {
+        return {
+            accessToken: null,
+            fallbackToken: null,
+            refreshToken: null,
+        };
+    }
+
+    const accessToken = findFirstStringValue(nodes, ACCESS_TOKEN_KEYS);
+    const refreshToken = findFirstStringValue(nodes, REFRESH_TOKEN_KEYS);
+    const fallbackToken = findFirstStringValue(nodes, FALLBACK_TOKEN_KEYS) ?? accessToken;
+
+    return {
+        accessToken: accessToken ?? null,
+        fallbackToken: fallbackToken ?? null,
+        refreshToken: refreshToken ?? null,
+    };
+};
+
+export const previewToken = (token?: string | null): string => {
+    const sanitized = sanitizeToken(token);
+    if (!sanitized) {
+        return 'null';
+    }
+
+    const visibleLength = 20;
+    return sanitized.length > visibleLength
+        ? `${sanitized.substring(0, visibleLength)}...`
+        : sanitized;
+};
+
+export const clearTokens = (): void => {
+    const storage = getStorage();
+    if (!storage) {
+        return;
+    }
+
+    storage.removeItem(AUTH_TOKEN_KEY);
+    storage.removeItem(ACCESS_TOKEN_KEY);
+    storage.removeItem(REFRESH_TOKEN_KEY);
+};
+
+export const cleanInvalidTokens = (): void => {
+    const storage = getStorage();
+    if (!storage) {
+        return;
+    }
+
+    const entries: Array<[key: string, value: string | null]> = [
+        [AUTH_TOKEN_KEY, storage.getItem(AUTH_TOKEN_KEY)],
+        [ACCESS_TOKEN_KEY, storage.getItem(ACCESS_TOKEN_KEY)],
+        [REFRESH_TOKEN_KEY, storage.getItem(REFRESH_TOKEN_KEY)],
+    ];
+
+    entries.forEach(([key, value]) => {
+        if (!sanitizeToken(value)) {
+            storage.removeItem(key);
+        }
+    });
+};
+
+export const persistTokens = ({
+    accessToken,
+    refreshToken,
+    fallbackToken,
+}: {
+    accessToken?: string | null;
+    refreshToken?: string | null;
+    fallbackToken?: string | null;
+}): { accessToken: string | null; refreshToken: string | null } => {
+    const storage = getStorage();
+    if (!storage) {
+        return { accessToken: null, refreshToken: null };
+    }
+
+    const primaryToken = pickValidToken(accessToken, fallbackToken);
+    const sanitizedRefreshToken = pickValidToken(refreshToken);
+
+    if (!primaryToken) {
+        clearTokens();
+        return { accessToken: null, refreshToken: null };
+    }
+
+    storage.setItem(AUTH_TOKEN_KEY, primaryToken);
+    storage.setItem(ACCESS_TOKEN_KEY, primaryToken);
+
+    if (sanitizedRefreshToken) {
+        storage.setItem(REFRESH_TOKEN_KEY, sanitizedRefreshToken);
+    } else {
+        storage.removeItem(REFRESH_TOKEN_KEY);
+    }
+
+    return {
+        accessToken: primaryToken,
+        refreshToken: sanitizedRefreshToken,
+    };
+};
+
+export const getStoredAccessToken = (): string | null => {
+    const storage = getStorage();
+    if (!storage) {
+        return null;
+    }
+
+    return pickValidToken(storage.getItem(AUTH_TOKEN_KEY), storage.getItem(ACCESS_TOKEN_KEY));
+};
+
+export const getStoredRefreshToken = (): string | null => {
+    const storage = getStorage();
+    if (!storage) {
+        return null;
+    }
+
+    return pickValidToken(storage.getItem(REFRESH_TOKEN_KEY));
+};
+
+export const getTokenSnapshot = (): {
+    keys: string[];
+    authToken: string | null;
+    accessToken: string | null;
+    refreshToken: string | null;
+} => {
+    const storage = getStorage();
+    if (!storage) {
+        return {
+            keys: [],
+            authToken: null,
+            accessToken: null,
+            refreshToken: null,
+        };
+    }
+
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index);
+        if (key) {
+            keys.push(key);
+        }
+    }
+
+    return {
+        keys,
+        authToken: storage.getItem(AUTH_TOKEN_KEY),
+        accessToken: storage.getItem(ACCESS_TOKEN_KEY),
+        refreshToken: storage.getItem(REFRESH_TOKEN_KEY),
+    };
+};
+
+export {
+    AUTH_TOKEN_KEY,
+    ACCESS_TOKEN_KEY,
+    REFRESH_TOKEN_KEY,
+};

--- a/src/features/auth/types/index.ts
+++ b/src/features/auth/types/index.ts
@@ -26,12 +26,14 @@ export interface SignupData {
 export interface AuthResponse {
     user: User;
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface RefreshTokenResponse {
     accessToken: string;
-    refreshToken: string;
+    refreshToken: string | null;
+    token?: string | null;
 }
 
 export interface PasswordResetRequest {

--- a/src/features/community/api/communityApi.ts
+++ b/src/features/community/api/communityApi.ts
@@ -13,6 +13,126 @@ import type {
 
 const API_BASE = '/community'
 
+const unwrapData = <T>(payload: any): T | null => {
+    if (payload === null || payload === undefined) {
+        return null
+    }
+
+    if (Array.isArray(payload)) {
+        return payload as T
+    }
+
+    if (typeof payload === 'object' && payload !== null && 'data' in payload) {
+        const value = (payload as { data?: T }).data
+        return (value ?? null) as T | null
+    }
+
+    return payload as T
+}
+
+const ensureArray = <T>(value: unknown, fallback: T[] = []): T[] => {
+    if (Array.isArray(value)) {
+        return value as T[]
+    }
+
+    return [...fallback]
+}
+
+const resolvePostsPayload = (payload: any): any[] => {
+    if (!payload) {
+        return []
+    }
+
+    if (Array.isArray(payload)) {
+        return payload
+    }
+
+    if (Array.isArray(payload.posts)) {
+        return payload.posts
+    }
+
+    if (Array.isArray(payload?.data?.posts)) {
+        return payload.data.posts
+    }
+
+    if (Array.isArray(payload?.data)) {
+        return payload.data
+    }
+
+    return []
+}
+
+const resolvePaginationPayload = (payload: any): any | undefined => {
+    if (!payload || typeof payload !== 'object') {
+        return undefined
+    }
+
+    if (payload.pagination && typeof payload.pagination === 'object') {
+        return payload.pagination
+    }
+
+    if (payload.data && typeof payload.data === 'object' && 'pagination' in payload.data) {
+        return (payload.data as Record<string, unknown>).pagination
+    }
+
+    return undefined
+}
+
+const normalizeAuthor = (post: any) => {
+    if (post && typeof post.author === 'object' && post.author !== null) {
+        return {
+            id: post.author.id || post.author._id || post.authorId || post.author?.id || 'unknown-author',
+            name: post.author.name || post.author.username || post.author.displayName || post.authorName || '익명',
+            username: post.author.username || post.author.name || post.author.email || 'anonymous',
+            role: post.author.role || 'user',
+            avatar: post.author.avatar || post.author.profileImage || undefined,
+            isVerified: Boolean(post.author.isVerified),
+        }
+    }
+
+    if (post?.author) {
+        return {
+            id: String(post.author),
+            name: post.authorName || post.authorNickname || '익명',
+            username: post.authorName || post.authorNickname || 'anonymous',
+            role: 'user' as const,
+        }
+    }
+
+    return {
+        id: post?.authorId ? String(post.authorId) : 'unknown-author',
+        name: post?.authorName || '익명',
+        username: post?.authorName || 'anonymous',
+        role: 'user' as const,
+    }
+}
+
+const countReactions = (value: unknown): number => {
+    if (Array.isArray(value)) {
+        return value.length
+    }
+
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value
+    }
+
+    return 0
+}
+
+const countReplies = (comments: unknown): number => {
+    if (!Array.isArray(comments)) {
+        return 0
+    }
+
+    return comments.reduce((total, comment) => {
+        if (comment && typeof comment === 'object' && Array.isArray((comment as any).replies)) {
+            return total + (comment as any).replies.length
+        }
+
+        return total
+    }, 0)
+}
+
 export const communityApi = {
     // 게시글 목록 조회
     getPosts: async (query: CommunityPostListQuery = {}): Promise<CommunityPostListResponse> => {
@@ -30,37 +150,100 @@ export const communityApi = {
         const queryString = params.toString()
         const endpoint = queryString ? `${API_BASE}/posts?${queryString}` : `${API_BASE}/posts`
 
-        const response = await apiCall<{ success: boolean; posts: any[]; pagination: any }>(endpoint)
+        try {
+            const response = await apiCall<{ posts?: any[]; pagination?: any } | { data?: any } | any[]>(endpoint)
 
-        // 데이터 변환 및 정규화
-        const normalizedPosts = response.posts.map(post => ({
-            ...post,
-            id: post.id || post._id,
-            views: post.viewCount || post.views || 0,
-            likes: Array.isArray(post.likes) ? post.likes.length : (post.likes || 0),
-            dislikes: Array.isArray(post.dislikes) ? post.dislikes.length : (post.dislikes || 0),
-            replies: Array.isArray(post.comments) ? post.comments.length : (post.replies || 0),
-            author: typeof post.author === 'string' ? { id: post.author, name: post.authorName || 'Unknown', role: 'user' } : post.author,
-            isHot: (Array.isArray(post.likes) ? post.likes.length : post.likes || 0) > 10 || (post.viewCount || post.views || 0) > 100,
-            isPinned: false,
-            status: 'published' as const,
-            createdAt: post.createdAt || new Date().toISOString(),
-            updatedAt: post.updatedAt || new Date().toISOString()
-        }))
+            const rawPosts = resolvePostsPayload(response)
 
-        return {
-            posts: normalizedPosts,
-            pagination: response.pagination
+            const normalizedPosts: CommunityPost[] = rawPosts.map((post: any) => {
+                const likes = countReactions(post?.likes)
+                const dislikes = countReactions(post?.dislikes)
+                const commentsArray = ensureArray<any>(post?.comments)
+                const commentsCount = countReactions(commentsArray)
+                const repliesCount = countReplies(commentsArray)
+                const tags = ensureArray<string>(post?.tags).filter(tag => typeof tag === 'string' && tag.trim().length > 0)
+                const fallbackTags = ensureArray<string>(post?.tagList).filter(tag => typeof tag === 'string' && tag.trim().length > 0)
+                const createdAt = post?.createdAt ? new Date(post.createdAt) : new Date()
+                const updatedAt = post?.updatedAt ? new Date(post.updatedAt) : createdAt
+
+                const viewCount = typeof post?.viewCount === 'number'
+                    ? post.viewCount
+                    : typeof post?.views === 'number'
+                        ? post.views
+                        : 0
+
+                const fallbackId = post?.id || post?._id || post?.postId || post?.slug
+                    || `temp-${Math.random().toString(36).slice(2, 10)}`
+
+                const normalizedPost: CommunityPost = {
+                    id: String(fallbackId),
+                    title: typeof post?.title === 'string' ? post.title : '제목 미상',
+                    content: typeof post?.content === 'string' ? post.content : '',
+                    author: normalizeAuthor(post),
+                    category: typeof post?.category === 'string' ? post.category : '자유',
+                    tags: tags.length > 0 ? tags : fallbackTags,
+                    likes,
+                    dislikes,
+                    views: viewCount,
+                    viewCount,
+                    comments: commentsCount,
+                    replies: repliesCount,
+                    isHot: typeof post?.isHot === 'boolean' ? post.isHot : likes > 10 || viewCount > 100,
+                    isPinned: Boolean(post?.isPinned || post?.isNotice),
+                    isLiked: Boolean(post?.isLiked),
+                    isDisliked: Boolean(post?.isDisliked),
+                    isBookmarked: Boolean(post?.isBookmarked),
+                    status: (post?.status as CommunityPost['status']) || 'published',
+                    createdAt: !Number.isNaN(createdAt.getTime()) ? createdAt.toISOString() : new Date().toISOString(),
+                    updatedAt: !Number.isNaN(updatedAt.getTime()) ? updatedAt.toISOString() : new Date().toISOString(),
+                }
+
+                return normalizedPost
+            })
+
+            const paginationPayload = resolvePaginationPayload(response)
+
+            const normalizedPagination = paginationPayload
+                ? {
+                    page: Number(paginationPayload.page ?? 1) || 1,
+                    limit: Number(paginationPayload.limit ?? normalizedPosts.length) || normalizedPosts.length || 10,
+                    total: Number(paginationPayload.total ?? normalizedPosts.length) || normalizedPosts.length,
+                    pages: Number(paginationPayload.pages ?? paginationPayload.totalPages ?? 1) || 1,
+                    totalPages: Number(paginationPayload.totalPages ?? paginationPayload.pages ?? 1) || 1,
+                }
+                : {
+                    page: 1,
+                    limit: normalizedPosts.length,
+                    total: normalizedPosts.length,
+                    pages: normalizedPosts.length > 0 ? 1 : 0,
+                    totalPages: normalizedPosts.length > 0 ? 1 : 0,
+                }
+
+            return {
+                posts: normalizedPosts,
+                pagination: normalizedPagination,
+            }
+        } catch (error) {
+            console.error('커뮤니티 게시글 목록 조회 실패:', error)
+            throw new Error(
+                error instanceof Error
+                    ? error.message
+                    : '커뮤니티 게시글을 불러오는 중 오류가 발생했습니다.',
+            )
         }
     },
 
     // 게시글 상세 조회
     getPost: async (postId: string): Promise<CommunityPost> => {
         try {
-            const response = await apiCall<{ success: boolean; data: any }>(`${API_BASE}/posts/${postId}`)
+            const response = await apiCall<{ data?: any }>(`${API_BASE}/posts/${postId}`)
+            const post = unwrapData<any>(response)
+
+            if (!post) {
+                throw new Error('게시글 데이터를 찾을 수 없습니다.')
+            }
 
             // 데이터 변환 및 정규화
-            const post = response.data
             const normalizedPost: CommunityPost = {
                 ...post,
                 id: post.id || post._id,
@@ -85,26 +268,34 @@ export const communityApi = {
 
     // 게시글 생성
     createPost: async (data: CreateCommunityPostData): Promise<CommunityPost> => {
-        const response = await apiCall<{ success: boolean; data: CommunityPost; message: string }>(`${API_BASE}/posts`, {
+        const response = await apiCall<{ data?: CommunityPost }>(`${API_BASE}/posts`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(data),
         })
-        return response.data
+        const result = unwrapData<CommunityPost>(response)
+        if (!result) {
+            throw new Error('게시글 생성 응답이 비어 있습니다.')
+        }
+        return result
     },
 
     // 게시글 수정
     updatePost: async (postId: string, data: UpdateCommunityPostData): Promise<CommunityPost> => {
-        const response = await apiCall<{ success: boolean; data: CommunityPost; message: string }>(`${API_BASE}/posts/${postId}`, {
+        const response = await apiCall<{ data?: CommunityPost }>(`${API_BASE}/posts/${postId}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(data),
         })
-        return response.data
+        const result = unwrapData<CommunityPost>(response)
+        if (!result) {
+            throw new Error('게시글 수정 응답이 비어 있습니다.')
+        }
+        return result
     },
 
     // 게시글 삭제
@@ -116,20 +307,22 @@ export const communityApi = {
 
     // 게시글 좋아요
     likePost: async (postId: string): Promise<{ likes: number }> => {
-        const response = await apiCall<{ success: boolean; data: { likes: number; dislikes: number }; message: string }>(`${API_BASE}/posts/${postId}/reactions`, {
+        const response = await apiCall<{ data?: { likes: number; dislikes: number } }>(`${API_BASE}/posts/${postId}/reactions`, {
             method: 'POST',
             body: JSON.stringify({ reaction: 'like' }),
         })
-        return { likes: response.data.likes }
+        const result = unwrapData<{ likes: number; dislikes: number }>(response)
+        return { likes: result?.likes ?? 0 }
     },
 
     // 게시글 조회수 증가
     viewPost: async (postId: string): Promise<{ views: number }> => {
         try {
-            const response = await apiCall<{ success: boolean; data: { views: number }; message: string }>(`${API_BASE}/posts/${postId}/views`, {
+            const response = await apiCall<{ data?: { views: number } }>(`${API_BASE}/posts/${postId}/views`, {
                 method: 'POST',
             })
-            return { views: response.data.views }
+            const result = unwrapData<{ views: number }>(response)
+            return { views: result?.views ?? 0 }
         } catch (error) {
             console.error('조회수 증가 실패:', error)
             throw error
@@ -138,32 +331,40 @@ export const communityApi = {
 
     // 댓글 목록 조회
     getComments: async (postId: string): Promise<CommunityComment[]> => {
-        const response = await apiCall<{ success: boolean; data: CommunityComment[]; pagination: any }>(`${API_BASE}/posts/${postId}/comments`)
-        return response.data
+        const response = await apiCall<{ data?: CommunityComment[] }>(`${API_BASE}/posts/${postId}/comments`)
+        return unwrapData<CommunityComment[]>(response) ?? []
     },
 
     // 댓글 생성
     createComment: async (data: CreateCommunityCommentData): Promise<CommunityComment> => {
-        const response = await apiCall<{ success: boolean; data: CommunityComment; message: string }>(`${API_BASE}/posts/${data.postId}/comments`, {
+        const response = await apiCall<{ data?: CommunityComment }>(`${API_BASE}/posts/${data.postId}/comments`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify({ content: data.content, parentId: data.parentId }),
         })
-        return response.data
+        const result = unwrapData<CommunityComment>(response)
+        if (!result) {
+            throw new Error('댓글 생성 응답이 비어 있습니다.')
+        }
+        return result
     },
 
     // 댓글 수정
     updateComment: async (postId: string, commentId: string, content: string): Promise<CommunityComment> => {
-        const response = await apiCall<{ success: boolean; data: CommunityComment; message: string }>(`${API_BASE}/posts/${postId}/comments/${commentId}`, {
+        const response = await apiCall<{ data?: CommunityComment }>(`${API_BASE}/posts/${postId}/comments/${commentId}`, {
             method: 'PUT',
             headers: {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify({ content }),
         })
-        return response.data
+        const result = unwrapData<CommunityComment>(response)
+        if (!result) {
+            throw new Error('댓글 수정 응답이 비어 있습니다.')
+        }
+        return result
     },
 
     // 댓글 삭제
@@ -175,28 +376,29 @@ export const communityApi = {
 
     // 댓글 좋아요
     likeComment: async (postId: string, commentId: string): Promise<{ likes: number }> => {
-        const response = await apiCall<{ success: boolean; data: { likes: number; dislikes: number }; message: string }>(`${API_BASE}/posts/${postId}/comments/${commentId}/reactions`, {
+        const response = await apiCall<{ data?: { likes: number; dislikes: number } }>(`${API_BASE}/posts/${postId}/comments/${commentId}/reactions`, {
             method: 'POST',
             body: JSON.stringify({ reaction: 'like' }),
         })
-        return { likes: response.data.likes }
+        const result = unwrapData<{ likes: number; dislikes: number }>(response)
+        return { likes: result?.likes ?? 0 }
     },
 
     // 카테고리 목록 조회
     getCategories: async (): Promise<CommunityCategory[]> => {
-        const response = await apiCall<{ success: boolean; data: CommunityCategory[] }>('/categories')
-        return response.data
+        const response = await apiCall<{ data?: CommunityCategory[] }>(`${API_BASE}/categories`)
+        return unwrapData<CommunityCategory[]>(response) ?? []
     },
 
     // 인기 게시글 조회
     getPopularPosts: async (limit: number = 10): Promise<CommunityPost[]> => {
-        const response = await apiCall<{ success: boolean; data: CommunityPost[] }>(`${API_BASE}/posts/popular?limit=${limit}`)
-        return response.data
+        const response = await apiCall<{ data?: CommunityPost[] }>(`${API_BASE}/posts/popular?limit=${limit}`)
+        return unwrapData<CommunityPost[]>(response) ?? []
     },
 
     // 최신 게시글 조회
     getRecentPosts: async (limit: number = 10): Promise<CommunityPost[]> => {
-        const response = await apiCall<{ success: boolean; data: CommunityPost[] }>(`${API_BASE}/posts/recent?limit=${limit}`)
-        return response.data
+        const response = await apiCall<{ data?: CommunityPost[] }>(`${API_BASE}/posts/recent?limit=${limit}`)
+        return unwrapData<CommunityPost[]>(response) ?? []
     },
 }

--- a/src/features/community/components/PostCard.tsx
+++ b/src/features/community/components/PostCard.tsx
@@ -150,7 +150,7 @@ const PostCard: React.FC<PostCardProps> = ({
                         </p>
                     </div>
 
-                    {post.tags.length > 0 && (
+                    {Array.isArray(post.tags) && post.tags.length > 0 && (
                         <div className="flex flex-wrap gap-2">
                             {post.tags.map((tag, index) => (
                                 <span

--- a/src/features/community/types.ts
+++ b/src/features/community/types.ts
@@ -58,6 +58,7 @@ export interface CommunityPostListResponse {
         limit: number
         total: number
         totalPages: number
+        pages?: number
     }
 }
 

--- a/src/features/community/types/index.ts
+++ b/src/features/community/types/index.ts
@@ -58,11 +58,11 @@ export interface CommunityCategory {
 
 export interface CommunityStats {
     totalPosts: number;
+    activeUsers: number;
     totalComments: number;
-    totalUsers: number;
-    totalLikes: number;
-    avgLikesPerPost: number;
-    avgCommentsPerPost: number;
+    avgLikes: number;
+    postsGrowthRate: number;
+    usersGrowthRate: number;
 }
 
 export interface PostListParams {
@@ -118,6 +118,7 @@ export interface PostListResponse {
         limit: number;
         total: number;
         pages: number;
+        totalPages?: number;
     };
     stats?: CommunityStats;
 }

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -4,6 +4,16 @@ import axios, {
   AxiosRequestConfig,
   AxiosResponse,
 } from 'axios';
+import {
+  clearTokens,
+  cleanInvalidTokens,
+  getStoredAccessToken,
+  getStoredRefreshToken,
+  getTokenSnapshot,
+  persistTokens,
+  previewToken,
+  resolveAuthTokenCandidates,
+} from '@/features/auth/services/tokenStorage';
 import { resolveApiBaseUrl } from '@/lib/config/env';
 import {
   ApiResponse,
@@ -24,38 +34,31 @@ class ApiClient {
       },
     });
 
+    cleanInvalidTokens();
     this.setupInterceptors();
   }
 
   private setupInterceptors() {
     this.client.interceptors.request.use(
       config => {
-        const authToken = localStorage.getItem('authToken');
-        const accessToken = localStorage.getItem('accessToken');
-        
-        // "undefined" 문자열이나 null 값 필터링
-        const validAuthToken = authToken && authToken !== 'null' && authToken !== 'undefined' ? authToken : null;
-        const validAccessToken = accessToken && accessToken !== 'null' && accessToken !== 'undefined' ? accessToken : null;
-        
-        const token = validAuthToken ?? validAccessToken;
+        const token = getStoredAccessToken();
+        const refreshToken = getStoredRefreshToken();
 
         // 디버깅을 위한 로그
         console.log('🔍 API Request Debug:', {
           url: config.url,
-          authToken: authToken ? `${authToken.substring(0, 20)}...` : 'null',
-          accessToken: accessToken
-            ? `${accessToken.substring(0, 20)}...`
-            : 'null',
-          selectedToken: token ? `${token.substring(0, 20)}...` : 'null',
+          accessToken: previewToken(token),
+          refreshToken: previewToken(refreshToken),
           headers: config.headers,
         });
 
         // localStorage 전체 상태 확인
+        const snapshot = getTokenSnapshot();
         console.log('🔍 localStorage 전체 상태:', {
-          allKeys: Object.keys(localStorage),
-          authToken: localStorage.getItem('authToken'),
-          accessToken: localStorage.getItem('accessToken'),
-          refreshToken: localStorage.getItem('refreshToken')
+          keys: snapshot.keys,
+          authToken: previewToken(snapshot.authToken),
+          accessToken: previewToken(snapshot.accessToken),
+          refreshToken: previewToken(snapshot.refreshToken),
         });
 
         if (token) {
@@ -74,7 +77,7 @@ class ApiClient {
       async error => {
         // 401 에러 시 토큰 갱신 시도
         if (error.response?.status === 401) {
-          const refreshToken = localStorage.getItem('refreshToken');
+          const refreshToken = getStoredRefreshToken();
           if (refreshToken) {
             try {
               console.log('🔄 Attempting token refresh...');
@@ -91,18 +94,28 @@ class ApiClient {
 
               if (response.ok) {
                 const data = await response.json();
-                if (data.success && data.data) {
-                  // 새로운 토큰 저장
-                  localStorage.setItem('authToken', data.data.accessToken);
-                  localStorage.setItem('accessToken', data.data.accessToken);
-                  localStorage.setItem('refreshToken', data.data.refreshToken);
+                if (data.success) {
+                  const tokenCandidates = resolveAuthTokenCandidates(data.data ?? data);
+                  const storedTokens = persistTokens({
+                    accessToken: tokenCandidates.accessToken,
+                    fallbackToken: tokenCandidates.fallbackToken,
+                    refreshToken: tokenCandidates.refreshToken ?? refreshToken,
+                  });
 
-                  console.log('✅ Token refreshed successfully');
+                  if (storedTokens.accessToken) {
+                    console.log('✅ Token refreshed successfully', {
+                      accessToken: previewToken(storedTokens.accessToken),
+                      refreshToken: previewToken(storedTokens.refreshToken),
+                    });
 
-                  // 원래 요청 재시도
-                  const originalRequest = error.config;
-                  originalRequest.headers.Authorization = `Bearer ${data.data.accessToken}`;
-                  return this.client.request(originalRequest);
+                    const originalRequest = error.config;
+                    originalRequest.headers = originalRequest.headers ?? {};
+                    originalRequest.headers.Authorization = `Bearer ${storedTokens.accessToken}`;
+                    return this.client.request(originalRequest);
+                  }
+
+                  console.error('❌ Token refresh failed: response did not contain a usable token.');
+                  clearTokens();
                 }
               }
             } catch (refreshError) {
@@ -119,9 +132,7 @@ class ApiClient {
   private clearStoredAuth(
     reason: 'unauthorized' | 'forbidden' | 'unknown' = 'unknown',
   ) {
-    localStorage.removeItem('authToken');
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+    clearTokens();
     localStorage.removeItem('authUser');
 
     if (typeof window !== 'undefined') {

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -32,7 +32,12 @@ class ApiClient {
       config => {
         const authToken = localStorage.getItem('authToken');
         const accessToken = localStorage.getItem('accessToken');
-        const token = authToken ?? accessToken;
+        
+        // "undefined" 문자열이나 null 값 필터링
+        const validAuthToken = authToken && authToken !== 'null' && authToken !== 'undefined' ? authToken : null;
+        const validAccessToken = accessToken && accessToken !== 'null' && accessToken !== 'undefined' ? accessToken : null;
+        
+        const token = validAuthToken ?? validAccessToken;
 
         // 디버깅을 위한 로그
         console.log('🔍 API Request Debug:', {
@@ -43,6 +48,14 @@ class ApiClient {
             : 'null',
           selectedToken: token ? `${token.substring(0, 20)}...` : 'null',
           headers: config.headers,
+        });
+
+        // localStorage 전체 상태 확인
+        console.log('🔍 localStorage 전체 상태:', {
+          allKeys: Object.keys(localStorage),
+          authToken: localStorage.getItem('authToken'),
+          accessToken: localStorage.getItem('accessToken'),
+          refreshToken: localStorage.getItem('refreshToken')
         });
 
         if (token) {

--- a/src/lib/api/useCategories.ts
+++ b/src/lib/api/useCategories.ts
@@ -11,8 +11,17 @@ export const useCategories = () => {
   return useQuery({
     queryKey: ['community', 'categories'],
     queryFn: async (): Promise<Category[]> => {
-      const response = await apiCall<{ success: boolean; data: Category[] }>('/community/categories');
-      return response.data;
+      const response = await apiCall<Category[] | { success: boolean; data: Category[] }>('/community/categories');
+
+      if (Array.isArray(response)) {
+        return response;
+      }
+
+      if (response && typeof response === 'object' && 'data' in response) {
+        return response.data ?? [];
+      }
+
+      return [];
     },
     staleTime: 10 * 60 * 1000, // 10분
     gcTime: 30 * 60 * 1000, // 30분

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -91,11 +91,14 @@ export const HomePage: React.FC = () => {
       <div className='space-y-8 md:space-y-12'>
         {/* Hero Section */}
         <section className='relative flex min-h-screen items-center justify-center space-y-8 overflow-hidden py-8 text-center md:space-y-12 md:py-12'>
-          {/* Enhanced Background with top gradient */}
+          {/* Enhanced Background */}
           <div className='via-secondary/20 to-muted/30 pointer-events-none absolute inset-0 bg-gradient-to-br from-background' />
-          {/* 상단 흐림 → 중앙 짙음 그라데이션 */}
-          <div className='bg-gradient-top-to-center-strong pointer-events-none absolute inset-0' />
           <div className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_30%_20%,rgba(79,70,229,0.1),transparent_50%)]' />
+          
+          {/* 중앙 부분에만 그라데이션 적용 */}
+          <div className='pointer-events-none absolute left-1/2 top-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 transform'>
+            <div className='bg-gradient-top-to-center-strong h-full w-full rounded-full blur-3xl opacity-60' />
+          </div>
 
           {/* Animated Background Elements */}
           <div className='bg-primary/10 animate-float pointer-events-none absolute left-1/4 top-1/4 h-72 w-72 rounded-full blur-3xl' />

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,5 @@
+import { getStoredAccessToken } from '@/features/auth/services/tokenStorage';
+
 export type UserRole = 'fan' | 'artist' | 'admin';
 
 export interface SignupData {
@@ -94,7 +96,7 @@ export const getCurrentUser = (): any | null => {
 
 // 사용자 인증 상태 확인
 export const isAuthenticated = (): boolean => {
-  const token = localStorage.getItem('authToken');
+  const token = getStoredAccessToken();
   const user = getCurrentUser();
   return !!(token && user);
 };

--- a/vercel.json
+++ b/vercel.json
@@ -3,40 +3,10 @@
   "buildCommand": "npm run build",
   "outputDirectory": "build",
   "installCommand": "npm install --legacy-peer-deps",
-  "routes": [
+  "rewrites": [
     {
-      "src": "/assets/(.*)",
-      "headers": {
-        "cache-control": "s-maxage=31536000,immutable",
-        "content-type": "application/javascript"
-      }
-    },
-    {
-      "src": "/static/(.*)",
-      "headers": {
-        "cache-control": "s-maxage=31536000,immutable"
-      }
-    },
-    {
-      "src": "/(.*\\.(js|css|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot))",
-      "headers": {
-        "cache-control": "s-maxage=31536000,immutable"
-      }
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ],
-  "headers": [
-    {
-      "source": "/(.*\\.js)",
-      "headers": [
-        {
-          "key": "Content-Type",
-          "value": "application/javascript; charset=utf-8"
-        }
-      ]
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary
- add a token candidate extractor that walks API payloads to find legacy `token`, `jwt`, and refresh token fields before sanitising
- update auth service, Axios refresh logic, and shared auth utilities to rely on the new helper and avoid re-saving undefined tokens
- gate community post form image uploads behind the sanitised access token and cover the new extraction logic with unit tests

## Testing
- npm run lint *(fails: missing dev dependency `@typescript-eslint/parser` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce816e53a883269890688bd33593e9