### PR TITLE
fix: sanitize api paths and community post payload

### DIFF
--- a/src/components/CommunityPostForm.tsx
+++ b/src/components/CommunityPostForm.tsx
@@ -170,6 +170,7 @@ export const CommunityPostForm: React.FC<CommunityPostFormProps> = ({
         content: formData.content.trim(),
         category: formData.category,
         tags: [],
+        images: imageUrls.length > 0 ? imageUrls : undefined,
         status: 'published' as const,
       };
 
@@ -178,7 +179,7 @@ export const CommunityPostForm: React.FC<CommunityPostFormProps> = ({
       setFormData({
         title: '',
         content: '',
-        category: '음악',
+        category: categories[0]?.id ?? 'music',
         images: [],
       });
       onBack(); // 포스트 생성 성공 시 뒤로가기

--- a/src/lib/config/__tests__/env.test.ts
+++ b/src/lib/config/__tests__/env.test.ts
@@ -67,8 +67,8 @@ describe('ensureApiPath', () => {
       expect(ensureApiPath(undefined as any)).toBe(undefined);
     });
 
-    it('슬래시만 있는 경우는 그대로 유지해야 함', () => {
-      expect(ensureApiPath('///')).toBe('///');
+    it('슬래시만 있는 경우에도 단일 루트 경로로 정규화해야 함', () => {
+      expect(ensureApiPath('///')).toBe('/');
     });
   });
 
@@ -134,5 +134,23 @@ describe('resolveApiBaseUrl', () => {
 
     const result = resolveApiBaseUrl();
     expect(result).toBe('https://api.example.com/api');
+  });
+
+  it('결합된 경로에서 중복 슬래시가 발생하지 않아야 함', () => {
+    process.env.VITE_API_BASE_URL = 'https://api.example.com/api/';
+
+    const baseUrl = resolveApiBaseUrl();
+    const combinedAbsolute = `${baseUrl}/auth/login`;
+    const absolutePathWithoutProtocol = combinedAbsolute.replace(
+      /^https?:\/\//,
+      '',
+    );
+
+    expect(absolutePathWithoutProtocol).not.toContain('//');
+
+    process.env.VITE_API_BASE_URL = '/api/';
+    const combinedRelative = `${resolveApiBaseUrl()}/auth/login`;
+
+    expect(combinedRelative).toBe('/api/auth/login');
   });
 });

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -58,14 +58,17 @@ export const ensureApiPath = (path: string): string => {
     return path;
   }
 
-  // 루트 경로는 그대로 유지
   if (path === '/') {
     return path;
   }
 
-  // 절대 경로와 상대 경로 모두에 대해 후행 슬래시 제거
-  // /\/+$/ 정규식으로 하나 이상의 연속된 슬래시를 끝에서 제거
-  return path.replace(/\/+$/, '');
+  const normalized = path.replace(/\/+$/, '');
+
+  if (normalized.length === 0) {
+    return '/';
+  }
+
+  return normalized;
 };
 
 export const resolveApiBaseUrl = (): string => {


### PR DESCRIPTION
## Summary
- normalize API paths by stripping trailing slashes with a single /\/+$ regex guard
- extend env configuration tests to cover absolute/relative trailing slash handling and prevent generated double slashes
- include uploaded image URLs when creating community posts and restore the category to a valid backend identifier after submission

## Testing
- npm test -- --runTestsByPath src/lib/config/__tests__/env.test.ts *(blocked: local Jest binary unavailable without installing dependencies)*
- npm run lint *(fails: missing @typescript-eslint/parser because npm install is blocked by a 403 when fetching dotenv)*

------
https://chatgpt.com/codex/tasks/task_b_68cf4c3f23708326b64c6ff5450db22a