### PR TITLE
Fix community routing and streamline board layout

### DIFF
--- a/src/features/community/components/PostTable.tsx
+++ b/src/features/community/components/PostTable.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui/Table';
+import { Badge } from '@/shared/ui/Badge';
+
+import { CommunityPost } from '../types';
+
+interface PostTableProps {
+  posts: CommunityPost[];
+  onPostClick?: (post: CommunityPost) => void;
+}
+
+const PostTable: React.FC<PostTableProps> = ({ posts, onPostClick }) => {
+  const getViews = (post: CommunityPost) => {
+    if (typeof post.views === 'number') {
+      return post.views;
+    }
+
+    if (typeof post.viewCount === 'number') {
+      return post.viewCount;
+    }
+
+    return 0;
+  };
+
+  const renderOrder = (post: CommunityPost, index: number) => {
+    if (post.isPinned) {
+      return <span className='font-semibold text-primary-600'>공지</span>;
+    }
+
+    return posts.length - index;
+  };
+
+  const formatDate = (value: string) => {
+    try {
+      return format(new Date(value), 'yy/MM/dd HH:mm', { locale: ko });
+    } catch (error) {
+      return value;
+    }
+  };
+
+  const handleClick = (post: CommunityPost) => {
+    if (onPostClick) {
+      onPostClick(post);
+    }
+  };
+
+  return (
+    <div className='overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm'>
+      <Table>
+        <TableHeader className='bg-gray-50'>
+          <TableRow>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              번호
+            </TableHead>
+            <TableHead className='text-sm font-medium text-gray-600'>제목</TableHead>
+            <TableHead className='w-32 text-center text-sm font-medium text-gray-600'>
+              글쓴이
+            </TableHead>
+            <TableHead className='w-32 text-center text-sm font-medium text-gray-600'>
+              작성일
+            </TableHead>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              조회
+            </TableHead>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              추천
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {posts.map((post, index) => (
+            <TableRow
+              key={post.id}
+              className='cursor-pointer transition-colors hover:bg-gray-50'
+              onClick={() => handleClick(post)}
+            >
+              <TableCell className='text-center text-sm text-gray-500'>
+                {renderOrder(post, index)}
+              </TableCell>
+              <TableCell className='max-w-0'>
+                <div className='flex items-center gap-2'>
+                  {post.category && (
+                    <Badge variant='outline' size='sm' className='shrink-0 text-xs'>
+                      {post.category}
+                    </Badge>
+                  )}
+                  <span className='truncate text-sm font-medium text-gray-900 hover:text-primary-600'>
+                    {post.title}
+                  </span>
+                  {post.comments > 0 && (
+                    <span className='text-xs text-primary-600'>[{post.comments}]</span>
+                  )}
+                  {post.isHot && (
+                    <Badge
+                      variant='outline'
+                      tone='danger'
+                      size='sm'
+                      className='shrink-0 text-xs'
+                    >
+                      인기
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {post.author?.name || post.author?.username || '익명'}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {formatDate(post.createdAt)}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {getViews(post).toLocaleString()}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {post.likes.toLocaleString()}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default PostTable;

--- a/src/features/community/hooks/useCommunity.ts
+++ b/src/features/community/hooks/useCommunity.ts
@@ -191,11 +191,12 @@ export const useCommunityCategories = () => {
 };
 
 // 커뮤니티 통계 조회
-export const useCommunityStats = () => {
+export const useCommunityStats = (options?: { enabled?: boolean }) => {
     return useQuery<CommunityStats>({
         queryKey: ['community', 'stats'],
         queryFn: () => communityPostAPI.getStats() as Promise<CommunityStats>,
         staleTime: 10 * 60 * 1000, // 10분
+        enabled: options?.enabled ?? true,
     });
 };
 

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,25 +1,15 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import CommunityMain from '../../features/community/components/CommunityMain';
-import { CommunityPost } from '../../features/community/types/index';
+
+import CommunityMain from '@/features/community/components/CommunityMain';
+import { CommunityPost } from '@/features/community/types';
 
 export const CommunityPage: React.FC = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const handlePostClick = (post: CommunityPost) => {
-        navigate(`/community/${post.id}`);
-    };
+  const handlePostClick = (post: CommunityPost) => {
+    navigate(`/community/post/${post.id}`);
+  };
 
-    const handleCreatePost = () => {
-        // 게시글 작성 로직은 CommunityMain 내부에서 처리됨
-        console.log('게시글 작성 요청');
-    };
-
-    return (
-        <CommunityMain
-            onPostClick={handlePostClick}
-            onCreatePost={handleCreatePost}
-            showStats={true}
-        />
-    );
+  return <CommunityMain onPostClick={handlePostClick} showStats={false} />;
 };


### PR DESCRIPTION
## Summary
- ensure community post navigation routes to the detail view and hide the stat summary on the landing page
- introduce a table-based community listing to emphasize core board functionality similar to the provided reference
- allow community stats queries to be disabled when stats are hidden to avoid unnecessary requests

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser because npm install is blocked by registry 403 for dotenv)*

------
https://chatgpt.com/codex/tasks/task_b_68d0fa5d00748326a6f83de357f7eb71