### PR TITLE
Refine community board focus and stabilize detail route

### DIFF
--- a/src/components/CommunityPostDetail.tsx
+++ b/src/components/CommunityPostDetail.tsx
@@ -151,7 +151,7 @@ export const CommunityPostDetail: React.FC<CommunityPostDetailProps> = ({
 
     // 링크 복사 기능
     const handleCopyLink = async () => {
-        const link = `${window.location.origin}/community/post/${postId}`;
+        const link = `${window.location.origin}/community/${postId}`;
         try {
             await navigator.clipboard.writeText(link);
             setCopiedLink(true);
@@ -163,7 +163,7 @@ export const CommunityPostDetail: React.FC<CommunityPostDetailProps> = ({
 
     // 소셜 공유 기능
     const handleSocialShare = (platform: 'twitter' | 'facebook' | 'kakao') => {
-        const link = `${window.location.origin}/community/post/${postId}`;
+        const link = `${window.location.origin}/community/${postId}`;
         const title = post?.title || '게시글';
 
         switch (platform) {

--- a/src/features/community/components/PostTable.tsx
+++ b/src/features/community/components/PostTable.tsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui/Table';
+import { Badge } from '@/shared/ui/Badge';
+
+import { CommunityPost } from '../types';
+
+interface PostTableProps {
+  posts: CommunityPost[];
+  onPostClick?: (post: CommunityPost) => void;
+}
+
+const PostTable: React.FC<PostTableProps> = ({ posts, onPostClick }) => {
+  const getViews = (post: CommunityPost) => {
+    if (typeof post.views === 'number') {
+      return post.views;
+    }
+
+    if (typeof post.viewCount === 'number') {
+      return post.viewCount;
+    }
+
+    return 0;
+  };
+
+  const resolvedPosts = useMemo(() => {
+    return posts.map(post => {
+      const commentCount =
+        typeof post.comments === 'number'
+          ? post.comments
+          : typeof post.replies === 'number'
+            ? post.replies
+            : 0;
+
+      return {
+        ...post,
+        commentCount,
+      };
+    });
+  }, [posts]);
+
+  const renderOrder = (post: CommunityPost, index: number) => {
+    if (post.isPinned) {
+      return <span className='font-semibold text-primary-600'>공지</span>;
+    }
+
+    return resolvedPosts.length - index;
+  };
+
+  const formatDate = (value: string) => {
+    try {
+      return format(new Date(value), 'yy/MM/dd HH:mm', { locale: ko });
+    } catch (error) {
+      return value;
+    }
+  };
+
+  return (
+    <div className='overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm'>
+      <Table>
+        <TableHeader className='bg-gray-50'>
+          <TableRow>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              번호
+            </TableHead>
+            <TableHead className='text-sm font-medium text-gray-600'>제목</TableHead>
+            <TableHead className='w-32 text-center text-sm font-medium text-gray-600'>
+              글쓴이
+            </TableHead>
+            <TableHead className='w-32 text-center text-sm font-medium text-gray-600'>
+              작성일
+            </TableHead>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              조회
+            </TableHead>
+            <TableHead className='w-20 text-center text-sm font-medium text-gray-600'>
+              추천
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {resolvedPosts.map((post, index) => (
+            <TableRow
+              key={post.id}
+              className='transition-colors hover:bg-gray-50'
+              data-post-id={post.id}
+            >
+              <TableCell className='text-center text-sm text-gray-500'>
+                {renderOrder(post, index)}
+              </TableCell>
+              <TableCell className='max-w-0'>
+                <div className='flex items-center gap-2'>
+                  {post.category && (
+                    <Badge variant='outline' size='sm' className='shrink-0 text-xs'>
+                      {post.category}
+                    </Badge>
+                  )}
+                  <Link
+                    to={`/community/${post.id}`}
+                    onClick={() => onPostClick?.(post)}
+                    className='truncate text-sm font-medium text-gray-900 hover:text-primary-600'
+                  >
+                    {post.title}
+                  </Link>
+                  {post.commentCount > 0 && (
+                    <span className='text-xs text-primary-600'>[{post.commentCount}]</span>
+                  )}
+                  {post.isHot && (
+                    <Badge
+                      variant='outline'
+                      tone='danger'
+                      size='sm'
+                      className='shrink-0 text-xs'
+                    >
+                      인기
+                    </Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {post.author?.name || post.author?.username || '익명'}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {formatDate(post.createdAt)}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {getViews(post).toLocaleString()}
+              </TableCell>
+              <TableCell className='text-center text-sm text-gray-600'>
+                {post.likes.toLocaleString()}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+export default PostTable;

--- a/src/features/community/hooks/useCommunity.ts
+++ b/src/features/community/hooks/useCommunity.ts
@@ -191,11 +191,12 @@ export const useCommunityCategories = () => {
 };
 
 // 커뮤니티 통계 조회
-export const useCommunityStats = () => {
+export const useCommunityStats = (options?: { enabled?: boolean }) => {
     return useQuery<CommunityStats>({
         queryKey: ['community', 'stats'],
         queryFn: () => communityPostAPI.getStats() as Promise<CommunityStats>,
         staleTime: 10 * 60 * 1000, // 10분
+        enabled: options?.enabled ?? true,
     });
 };
 

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,25 +1,15 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import CommunityMain from '../../features/community/components/CommunityMain';
-import { CommunityPost } from '../../features/community/types/index';
+
+import CommunityMain from '@/features/community/components/CommunityMain';
+import { CommunityPost } from '@/features/community/types';
 
 export const CommunityPage: React.FC = () => {
-    const navigate = useNavigate();
+  const navigate = useNavigate();
 
-    const handlePostClick = (post: CommunityPost) => {
-        navigate(`/community/${post.id}`);
-    };
+  const handlePostClick = (post: CommunityPost) => {
+    navigate(`/community/${post.id}`);
+  };
 
-    const handleCreatePost = () => {
-        // 게시글 작성 로직은 CommunityMain 내부에서 처리됨
-        console.log('게시글 작성 요청');
-    };
-
-    return (
-        <CommunityMain
-            onPostClick={handlePostClick}
-            onCreatePost={handleCreatePost}
-            showStats={true}
-        />
-    );
+  return <CommunityMain onPostClick={handlePostClick} />;
 };

--- a/src/pages/search/SearchPage.tsx
+++ b/src/pages/search/SearchPage.tsx
@@ -82,7 +82,7 @@ export const SearchPage: React.FC = () => {
             case 'artist': return `/artists/${result.id}`;
             case 'project': return `/projects/${result.id}`;
             case 'event': return `/events/${result.id}`;
-            case 'post': return `/community/post/${result.id}`;
+            case 'post': return `/community/${result.id}`;
             default: return '#';
         }
     };

--- a/src/routes/routeGroups.tsx
+++ b/src/routes/routeGroups.tsx
@@ -44,6 +44,7 @@ const routeGroups: RouteGroup[] = [
       { path: '/community', component: CommunityPage, layout: 'app' },
       { path: '/community/create', component: CreatePostPage, layout: 'app' },
       { path: '/community/edit/:postId', component: EditPostPage, layout: 'app' },
+      { path: '/community/:id', component: CommunityPostDetailRoute, layout: 'app', suspense: false },
       { path: '/community/post/:id', component: CommunityPostDetailRoute, layout: 'app', suspense: false },
       { path: '/notices', component: NoticesPage, layout: 'app' },
       { path: '/notices/:id', component: CommunityPostDetailRoute, layout: 'app', suspense: false },

--- a/src/routes/wrappers/CommunityPostDetailRoute.tsx
+++ b/src/routes/wrappers/CommunityPostDetailRoute.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { CommunityPostDetail } from '@/components/CommunityPostDetail';
@@ -6,19 +6,34 @@ import { CommunityPostDetail } from '@/components/CommunityPostDetail';
 export const CommunityPostDetailRoute: React.FC = () => {
   const navigate = useNavigate();
   const params = useParams<{ id?: string; postId?: string }>();
+  const postId = useMemo(() => {
+    const rawId = params.id ?? params.postId ?? '';
+    if (!rawId) {
+      return '';
+    }
 
-  const postId = params.id ?? params.postId ?? '';
+    const normalized = rawId.split(/[?#]/)[0]?.trim();
+    return normalized ?? '';
+  }, [params.id, params.postId]);
+
+  useEffect(() => {
+    if (!postId) {
+      navigate('/community', { replace: true });
+    }
+  }, [navigate, postId]);
 
   return (
-    <CommunityPostDetail
-      postId={postId}
-      onBack={() => {
-        if (window.history.length > 1) {
-          navigate(-1);
-        } else {
-          navigate('/community');
-        }
-      }}
-    />
+    postId ? (
+      <CommunityPostDetail
+        postId={postId}
+        onBack={() => {
+          if (window.history.length > 1) {
+            navigate(-1);
+          } else {
+            navigate('/community');
+          }
+        }}
+      />
+    ) : null
   );
 };


### PR DESCRIPTION
## Summary
- remove the stat dashboard from the community hub and add quick filter tiles so the layout highlights board interactions
- update the community table to deep-link to `/community/:id`, display comment badges, and keep row ordering consistent
- harden the community post detail wrapper to normalize ids from direct links before rendering the detail screen

## Testing
- npm install --legacy-peer-deps *(fails: npm registry returns 403 Forbidden while fetching audit/advisories)*
- npm run lint *(fails: local eslint deps such as @typescript-eslint/parser are unavailable because install above did not complete)*

------
https://chatgpt.com/codex/tasks/task_b_68d0fa5d00748326a6f83de357f7eb71