### PR TITLE
fix: preserve zero artist share in monthly earnings

### DIFF
--- a/server/routes/artists.js
+++ b/server/routes/artists.js
@@ -36,9 +36,9 @@ async function calculateMonthlyEarnings(artistId) {
 
     for (const project of completedProjects) {
       // 아티스트 수익 계산 (플랫폼 수수료 제외)
-      const artistShare = project.revenueDistribution?.artistShare || 0.7;
+      const artistShare = project.revenueDistribution?.artistShare ?? 0.7;
       const totalRevenue =
-        project.revenueDistribution?.totalRevenue || project.currentAmount;
+        project.revenueDistribution?.totalRevenue ?? project.currentAmount;
       const artistEarnings = totalRevenue * artistShare;
 
       monthlyEarnings += artistEarnings;
@@ -905,3 +905,4 @@ router.put('/:id', auth, async (req, res) => {
 });
 
 module.exports = router;
+module.exports.calculateMonthlyEarnings = calculateMonthlyEarnings;

--- a/server/tests/calculateMonthlyEarnings.test.js
+++ b/server/tests/calculateMonthlyEarnings.test.js
@@ -1,0 +1,28 @@
+jest.mock('../models/FundingProject', () => ({
+  find: jest.fn(),
+}));
+
+const FundingProject = require('../models/FundingProject');
+const artistsModule = require('../routes/artists');
+
+describe('calculateMonthlyEarnings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps artistShare at 0 when provided', async () => {
+    const { calculateMonthlyEarnings } = artistsModule;
+
+    FundingProject.find.mockResolvedValue([
+      {
+        revenueDistribution: { artistShare: 0, totalRevenue: 1000 },
+        currentAmount: 500,
+      },
+    ]);
+
+    const result = await calculateMonthlyEarnings('artist-id');
+
+    expect(FundingProject.find).toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- use nullish coalescing in monthly earnings calculations so 0-valued revenue fields are respected
- expose the monthly earnings helper for testing
- add a regression test that locks in behavior when artistShare is 0

## Testing
- npm test -- calculateMonthlyEarnings

------
https://chatgpt.com/codex/tasks/task_b_68d155e286ec8326b4a0013e5a7b3e4d