### PR TITLE
feat: refactor funding project mapper

### DIFF
--- a/src/services/__tests__/fundingProjectMapper.test.ts
+++ b/src/services/__tests__/fundingProjectMapper.test.ts
@@ -1,0 +1,242 @@
+import {
+  mapBackers,
+  mapExecutionPlan,
+  mapExpenseRecords,
+  mapFundingProjectDetail,
+  mapRevenueDistribution,
+  mapRewards,
+  mapUpdates,
+} from '@/services/fundingProjectMapper';
+import type { FundingProjectPayload } from '@/types/fundingProject';
+
+describe('fundingProjectMapper', () => {
+  it('normalizes a fully populated funding project payload', () => {
+    const payload: FundingProjectPayload = {
+      id: 'project-1',
+      _id: 'mongo-project-1',
+      title: 'Amazing Project',
+      description: 'A project with detailed information.',
+      artist: { _id: 'artist-42', name: 'Collaboreum Artist' },
+      category: 'music',
+      goalAmount: '100000',
+      targetAmount: 120000,
+      currentAmount: '50000',
+      backers: [
+        {
+          id: 'backer-1',
+          userId: 'user-1',
+          userName: 'First Backer',
+          amount: '10000',
+          date: '2024-01-02T00:00:00.000Z',
+          status: '완료',
+        },
+      ],
+      daysLeft: '10',
+      image: 'https://example.com/project.jpg',
+      status: '진행중',
+      progressPercentage: '45',
+      startDate: '2024-01-01T00:00:00.000Z',
+      endDate: '2024-02-01T00:00:00.000Z',
+      story: 'Project story',
+      artistAvatar: 'https://example.com/avatar.jpg',
+      artistRating: 4.8,
+      featured: true,
+      rewards: [
+        {
+          id: 'reward-1',
+          title: 'Signed Album',
+          description: 'Limited signed edition.',
+          amount: '30000',
+          estimatedDelivery: '2024-04-01T00:00:00.000Z',
+          claimed: '5',
+          maxClaim: '50',
+        },
+      ],
+      updates: [
+        {
+          id: 'update-1',
+          title: 'Kickoff',
+          content: 'We have launched!',
+          date: '2024-01-03T00:00:00.000Z',
+          type: 'announcement',
+        },
+      ],
+      executionPlan: {
+        stages: [
+          {
+            id: 'stage-1',
+            name: 'Production',
+            description: 'Produce the album.',
+            budget: '60000',
+            startDate: '2024-01-05T00:00:00.000Z',
+            endDate: '2024-03-01T00:00:00.000Z',
+            status: '진행중',
+            progress: '50',
+          },
+        ],
+        totalBudget: '150000',
+      },
+      expenseRecords: [
+        {
+          id: 'expense-1',
+          category: '장비',
+          title: 'Studio Rental',
+          description: 'Two weeks in a studio.',
+          amount: '20000',
+          date: '2024-01-10T00:00:00.000Z',
+          receipt: 'https://example.com/receipt.jpg',
+          stage: 'stage-1',
+          verified: true,
+        },
+      ],
+      revenueDistribution: {
+        totalRevenue: '90000',
+        platformFee: { percentage: 5 },
+        artistShare: { amount: '60000' },
+        backerShare: 0.3,
+        distributions: [
+          {
+            id: 'distribution-1',
+            userName: 'First Backer',
+            originalAmount: '10000',
+            profitShare: '2000',
+            amount: '12000',
+            date: '2024-02-10T00:00:00.000Z',
+            status: '완료',
+          },
+        ],
+      },
+    };
+
+    const mapped = mapFundingProjectDetail(payload);
+
+    expect(mapped).not.toBeNull();
+    expect(mapped?.id).toBe('project-1');
+    expect(mapped?.artist).toBe('Collaboreum Artist');
+    expect(mapped?.goalAmount).toBe(100000);
+    expect(mapped?.targetAmount).toBe(120000);
+    expect(mapped?.currentAmount).toBe(50000);
+    expect(mapped?.backers).toBe(1);
+    expect(mapped?.rewards[0]).toEqual(
+      expect.objectContaining({
+        amount: 30000,
+        claimed: 5,
+        maxClaim: 50,
+      }),
+    );
+    expect(mapped?.updates[0]).toEqual(
+      expect.objectContaining({
+        title: 'Kickoff',
+        date: '2024-01-03T00:00:00.000Z',
+      }),
+    );
+    expect(mapped?.executionPlan.totalBudget).toBe(150000);
+    expect(mapped?.revenueDistribution.platformFee).toEqual(
+      expect.objectContaining({ amount: 4500, percentage: 5 }),
+    );
+    expect(mapped?.revenueDistribution.artistShare.percentage).toBeCloseTo(
+      66.67,
+      2,
+    );
+    expect(mapped?.revenueDistribution.backerShare).toEqual(
+      expect.objectContaining({ amount: 27000, percentage: 30 }),
+    );
+  });
+
+  it('handles partial payloads across dedicated helpers', () => {
+    const rewards = mapRewards([
+      {
+        title: 'Digital Download',
+        amount: '10000',
+      },
+    ]);
+    expect(rewards[0]).toMatchObject({
+      title: 'Digital Download',
+      amount: 10000,
+      claimed: undefined,
+    });
+
+    const updates = mapUpdates([
+      {
+        title: 'Coming soon',
+        content: 'Update pending',
+      },
+    ]);
+    expect(updates[0]).toMatchObject({
+      title: 'Coming soon',
+      date: '',
+    });
+
+    const backers = mapBackers({
+      backers: 5,
+      backersList: [
+        {
+          isAnonymous: true,
+          amount: '12000',
+        },
+        null,
+      ],
+    });
+    expect(backers).toHaveLength(1);
+    expect(backers[0]).toMatchObject({
+      userName: '익명 후원자',
+      amount: 12000,
+      status: '완료',
+    });
+
+    const executionPlan = mapExecutionPlan(
+      {
+        stages: [
+          {
+            name: 'Planning',
+            budget: '5000',
+            progress: '10',
+          },
+        ],
+      },
+      4200,
+    );
+    expect(executionPlan.totalBudget).toBe(4200);
+    expect(executionPlan.stages[0]).toMatchObject({
+      progress: 10,
+      status: '계획',
+    });
+
+    const revenueDistribution = mapRevenueDistribution(
+      {
+        platformFee: { percentage: '10' },
+        artistShare: { amount: '2000' },
+        backerShare: '0.25',
+        distributions: [
+          {
+            backer: { _id: 'backer-42' },
+            amount: '500',
+          },
+        ],
+      },
+      4000,
+    );
+    expect(revenueDistribution.platformFee.amount).toBe(400);
+    expect(revenueDistribution.backerShare).toMatchObject({
+      amount: 1000,
+      percentage: 25,
+    });
+    expect(revenueDistribution.distributions[0]).toMatchObject({
+      backer: 'backer-42',
+      amount: 500,
+      status: '대기',
+    });
+
+    const expenseRecords = mapExpenseRecords([
+      {
+        title: 'Travel',
+        amount: '800',
+      },
+    ]);
+    expect(expenseRecords[0]).toMatchObject({
+      title: 'Travel',
+      amount: 800,
+      verified: false,
+    });
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,7 +1,13 @@
 import { api } from '@/lib/api/api';
 import type { ApiError, ApiRequestConfig, ApiResponse } from '@/shared/types';
 import type { RealTimeAlert } from '@/types/admin';
-import type { FundingProject, RevenueShare } from '@/types/fundingProject';
+import type {
+  FundingProject,
+  FundingProjectPayload,
+} from '@/types/fundingProject';
+import { mapFundingProjectDetail } from './fundingProjectMapper';
+
+export { mapFundingProjectDetail } from './fundingProjectMapper';
 
 type ApiCallOptions = RequestInit & {
   params?: Record<string, unknown>;
@@ -54,87 +60,6 @@ class RequestQueue {
 
 const requestQueue = new RequestQueue();
 
-const toArray = <T>(value: T[] | undefined | null): T[] =>
-  Array.isArray(value) ? value : [];
-
-const toNumber = (value: unknown, fallback = 0): number => {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-
-  return fallback;
-};
-
-const toIsoString = (value: unknown): string => {
-  if (!value) {
-    return '';
-  }
-
-  const date = value instanceof Date ? value : new Date(value as string);
-  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
-};
-
-const createId = (value: unknown, prefix: string): string => {
-  if (!value) {
-    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-
-  if (typeof value === 'string') {
-    return value.trim() !== ''
-      ? value
-      : `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
-  }
-
-  if (typeof value === 'number') {
-    return String(value);
-  }
-
-  if (
-    typeof value === 'object' &&
-    '_id' in (value as Record<string, unknown>)
-  ) {
-    return createId((value as Record<string, unknown>)._id, prefix);
-  }
-
-  return String(value);
-};
-
-const mapRevenueShare = (
-  share: unknown,
-  totalRevenue: number,
-): RevenueShare => {
-  if (share && typeof share === 'object' && !Array.isArray(share)) {
-    const shareObject = share as { amount?: unknown; percentage?: unknown };
-    const derivedAmount =
-      typeof shareObject.percentage === 'number'
-        ? Math.round((shareObject.percentage / 100) * totalRevenue)
-        : 0;
-    const amount = toNumber(shareObject.amount, derivedAmount);
-    const percentage =
-      typeof shareObject.percentage === 'number'
-        ? shareObject.percentage
-        : totalRevenue > 0
-          ? Number(((amount / totalRevenue) * 100).toFixed(2))
-          : 0;
-
-    return {
-      amount,
-      percentage,
-    };
-  }
-
-  const ratio = toNumber(share);
-  return {
-    amount: Math.round(ratio * totalRevenue),
-    percentage: Number((ratio * 100).toFixed(2)),
-  };
-};
-
 const extractApiData = <T>(
   response: ApiResponse<T> | T | undefined,
 ): T | null => {
@@ -176,185 +101,6 @@ const extractApiData = <T>(
   }
 
   return response as T;
-};
-
-export const mapFundingProjectDetail = (
-  project: any,
-): FundingProject | null => {
-  if (!project) {
-    return null;
-  }
-
-  const totalRevenue = toNumber(
-    project?.revenueDistribution?.totalRevenue,
-    toNumber(project?.currentAmount),
-  );
-  const backersArray = project.backersList ?? project.backers;
-
-  const goalAmount = toNumber(
-    project.goalAmount,
-    toNumber(project.targetAmount),
-  );
-
-  return {
-    id: createId(project.id ?? project._id, 'project'),
-    title: typeof project.title === 'string' ? project.title : '',
-    description:
-      typeof project.description === 'string' ? project.description : '',
-    artist:
-      typeof project.artist === 'string'
-        ? project.artist
-        : typeof project.artistName === 'string'
-          ? project.artistName
-          : '',
-    category: typeof project.category === 'string' ? project.category : '',
-    goalAmount,
-    targetAmount: toNumber(project.targetAmount, goalAmount),
-    currentAmount: toNumber(project.currentAmount),
-    backers:
-      typeof project.backers === 'number'
-        ? project.backers
-        : Array.isArray(project.backers)
-          ? project.backers.length
-          : Array.isArray(project.backersList)
-            ? project.backersList.length
-            : 0,
-    daysLeft: toNumber(project.daysLeft),
-    image: typeof project.image === 'string' ? project.image : '',
-    status: typeof project.status === 'string' ? project.status : '',
-    progressPercentage: toNumber(
-      project.progressPercentage,
-      toNumber(project.progress),
-    ),
-    startDate: toIsoString(project.startDate),
-    endDate: toIsoString(project.endDate),
-    story:
-      typeof project.story === 'string'
-        ? project.story
-        : typeof project.description === 'string'
-          ? project.description
-          : undefined,
-    artistAvatar:
-      typeof project.artistAvatar === 'string'
-        ? project.artistAvatar
-        : undefined,
-    artistRating:
-      typeof project.artistRating === 'number'
-        ? project.artistRating
-        : undefined,
-    artistId: project.artistId
-      ? String(project.artistId)
-      : project.artist &&
-          typeof project.artist === 'object' &&
-          '_id' in project.artist
-        ? String((project.artist as { _id: unknown })._id)
-        : undefined,
-    featured:
-      typeof project.featured === 'boolean' ? project.featured : undefined,
-    rewards: toArray(project.rewards).map((reward: any) => ({
-      id: createId(reward.id ?? reward._id ?? reward.title, 'reward'),
-      title: typeof reward.title === 'string' ? reward.title : '',
-      description:
-        typeof reward.description === 'string' ? reward.description : '',
-      amount: toNumber(reward.amount),
-      estimatedDelivery: toIsoString(reward.estimatedDelivery),
-      claimed: typeof reward.claimed === 'number' ? reward.claimed : undefined,
-      maxClaim:
-        typeof reward.maxClaim === 'number' ? reward.maxClaim : undefined,
-    })),
-    updates: toArray(project.updates).map((update: any) => ({
-      id: createId(update.id ?? update._id ?? update.title, 'update'),
-      title: typeof update.title === 'string' ? update.title : '',
-      content: typeof update.content === 'string' ? update.content : '',
-      date: toIsoString(update.date ?? update.createdAt),
-      type: typeof update.type === 'string' ? update.type : undefined,
-      createdAt: update.createdAt ? toIsoString(update.createdAt) : undefined,
-    })),
-    backersList: toArray(backersArray).map((backer: any) => ({
-      id: createId(backer.id ?? backer._id ?? backer.user, 'backer'),
-      userId: backer.userId
-        ? String(backer.userId)
-        : backer.user
-          ? String(backer.user)
-          : undefined,
-      userName:
-        typeof backer.userName === 'string'
-          ? backer.userName
-          : backer.isAnonymous
-            ? '익명 후원자'
-            : '익명 후원자',
-      amount: toNumber(backer.amount),
-      date: toIsoString(backer.date ?? backer.backedAt),
-      status: typeof backer.status === 'string' ? backer.status : '완료',
-    })),
-    executionPlan: {
-      stages: toArray(project.executionPlan?.stages).map((stage: any) => ({
-        id: createId(stage.id ?? stage._id ?? stage.name, 'stage'),
-        name: typeof stage.name === 'string' ? stage.name : '',
-        description:
-          typeof stage.description === 'string' ? stage.description : '',
-        budget: toNumber(stage.budget),
-        startDate: toIsoString(stage.startDate),
-        endDate: toIsoString(stage.endDate),
-        status: typeof stage.status === 'string' ? stage.status : '계획',
-        progress: toNumber(stage.progress),
-      })),
-      totalBudget: toNumber(
-        project.executionPlan?.totalBudget,
-        toNumber(project.goalAmount),
-      ),
-    },
-    expenseRecords: toArray(project.expenseRecords).map((expense: any) => ({
-      id: createId(expense.id ?? expense._id ?? expense.title, 'expense'),
-      category: typeof expense.category === 'string' ? expense.category : '',
-      title: typeof expense.title === 'string' ? expense.title : '',
-      description:
-        typeof expense.description === 'string' ? expense.description : '',
-      amount: toNumber(expense.amount),
-      date: toIsoString(expense.date),
-      receipt: typeof expense.receipt === 'string' ? expense.receipt : '',
-      stage: expense.stage ? String(expense.stage) : '',
-      verified: Boolean(expense.verified),
-    })),
-    revenueDistribution: {
-      totalRevenue,
-      platformFee: mapRevenueShare(
-        project.revenueDistribution?.platformFee,
-        totalRevenue,
-      ),
-      artistShare: mapRevenueShare(
-        project.revenueDistribution?.artistShare,
-        totalRevenue,
-      ),
-      backerShare: mapRevenueShare(
-        project.revenueDistribution?.backerShare,
-        totalRevenue,
-      ),
-      distributions: toArray(project.revenueDistribution?.distributions).map(
-        (distribution: any) => ({
-          id: createId(
-            distribution.id ?? distribution._id ?? distribution.backer,
-            'distribution',
-          ),
-          backer: distribution.backer ? String(distribution.backer) : undefined,
-          userName:
-            typeof distribution.userName === 'string'
-              ? distribution.userName
-              : '익명 후원자',
-          originalAmount: toNumber(distribution.originalAmount),
-          profitShare: toNumber(distribution.profitShare),
-          amount: toNumber(distribution.amount ?? distribution.totalReturn),
-          date: toIsoString(distribution.date ?? distribution.distributedAt),
-          status:
-            typeof distribution.status === 'string'
-              ? distribution.status
-              : '대기',
-        }),
-      ),
-    },
-  };
-};
-
 // Header Normalizer
 const normalizeHeaders = (
   headers?: HeadersInit,
@@ -767,7 +513,7 @@ export const fundingAPI = {
 
   // 프로젝트 상세 조회
   getProject: async (projectId: string): Promise<FundingProject | null> => {
-    const response = await apiCall<ApiResponse<FundingProject>>(
+    const response = await apiCall<ApiResponse<FundingProjectPayload>>(
       `/funding/projects/${projectId}`,
     );
     return mapFundingProjectDetail(extractApiData(response));
@@ -775,7 +521,7 @@ export const fundingAPI = {
   getProjectDetail: async (
     projectId: string,
   ): Promise<FundingProject | null> => {
-    const response = await apiCall<ApiResponse<FundingProject>>(
+    const response = await apiCall<ApiResponse<FundingProjectPayload>>(
       `/funding/projects/${projectId}`,
     );
     return mapFundingProjectDetail(extractApiData(response));

--- a/src/services/fundingProjectMapper.ts
+++ b/src/services/fundingProjectMapper.ts
@@ -1,0 +1,353 @@
+import type {
+  Backer,
+  ExecutionPlan,
+  ExpenseRecord,
+  FundingProject,
+  FundingProjectBackerPayload,
+  FundingProjectDistributionPayload,
+  FundingProjectExecutionPlanPayload,
+  FundingProjectExpensePayload,
+  FundingProjectPayload,
+  FundingProjectRewardPayload,
+  FundingProjectUpdatePayload,
+  RevenueDistribution,
+  RevenueShare,
+  RevenueSharePayload,
+} from '@/types/fundingProject';
+
+const toArray = <T>(value?: readonly (T | null | undefined)[] | null): T[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter((item): item is T => item != null);
+};
+
+const toNumber = (value: unknown, fallback = 0): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+};
+
+const toIsoString = (value: unknown): string => {
+  if (!value) {
+    return '';
+  }
+
+  const date = value instanceof Date ? value : new Date(value as string);
+  return Number.isNaN(date.getTime()) ? '' : date.toISOString();
+};
+
+const createId = (value: unknown, prefix: string): string => {
+  if (!value) {
+    return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() !== ''
+      ? value
+      : `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    '_id' in (value as Record<string, unknown>)
+  ) {
+    return createId((value as Record<string, unknown>)._id, prefix);
+  }
+
+  return String(value);
+};
+
+const mapRevenueShare = (
+  share: RevenueSharePayload,
+  totalRevenue: number,
+): RevenueShare => {
+  if (share && typeof share === 'object' && !Array.isArray(share)) {
+    const shareObject = share as { amount?: unknown; percentage?: unknown };
+    const rawPercentage = shareObject.percentage;
+    const percentageValue =
+      typeof rawPercentage === 'number'
+        ? rawPercentage
+        : typeof rawPercentage === 'string'
+          ? toNumber(rawPercentage)
+          : undefined;
+    const derivedAmount =
+      percentageValue !== undefined
+        ? Math.round((percentageValue / 100) * totalRevenue)
+        : 0;
+    const amount = toNumber(shareObject.amount, derivedAmount);
+    const percentage =
+      percentageValue !== undefined
+        ? percentageValue
+        : totalRevenue > 0
+          ? Number(((amount / totalRevenue) * 100).toFixed(2))
+          : 0;
+
+    return {
+      amount,
+      percentage,
+    };
+  }
+
+  const ratio = toNumber(share);
+  return {
+    amount: Math.round(ratio * totalRevenue),
+    percentage: Number((ratio * 100).toFixed(2)),
+  };
+};
+
+export const mapRewards = (
+  rewards?: FundingProjectPayload['rewards'],
+): FundingProject['rewards'] => {
+  return toArray<FundingProjectRewardPayload>(rewards).map(reward => ({
+    id: createId(reward.id ?? reward._id ?? reward.title, 'reward'),
+    title: typeof reward.title === 'string' ? reward.title : '',
+    description:
+      typeof reward.description === 'string' ? reward.description : '',
+    amount: toNumber(reward.amount),
+    estimatedDelivery: toIsoString(reward.estimatedDelivery),
+    claimed:
+      typeof reward.claimed === 'number'
+        ? reward.claimed
+        : typeof reward.claimed === 'string'
+          ? toNumber(reward.claimed)
+          : undefined,
+    maxClaim:
+      typeof reward.maxClaim === 'number'
+        ? reward.maxClaim
+        : typeof reward.maxClaim === 'string'
+          ? toNumber(reward.maxClaim)
+          : undefined,
+  }));
+};
+
+export const mapUpdates = (
+  updates?: FundingProjectPayload['updates'],
+): FundingProject['updates'] => {
+  return toArray<FundingProjectUpdatePayload>(updates).map(update => ({
+    id: createId(update.id ?? update._id ?? update.title, 'update'),
+    title: typeof update.title === 'string' ? update.title : '',
+    content: typeof update.content === 'string' ? update.content : '',
+    date: toIsoString(update.date ?? update.createdAt),
+    type: typeof update.type === 'string' ? update.type : undefined,
+    createdAt: update.createdAt ? toIsoString(update.createdAt) : undefined,
+  }));
+};
+
+export const mapBackers = (
+  backers: Pick<FundingProjectPayload, 'backers' | 'backersList'>,
+): Backer[] => {
+  const fallbackBackers = Array.isArray(backers.backers)
+    ? backers.backers
+    : undefined;
+
+  return toArray<FundingProjectBackerPayload>(
+    backers.backersList ?? fallbackBackers,
+  ).map(backer => ({
+    id: createId(backer.id ?? backer._id ?? backer.user, 'backer'),
+    userId: backer.userId
+      ? String(backer.userId)
+      : backer.user
+        ? String(
+            typeof backer.user === 'object' && backer.user && '_id' in backer.user
+              ? (backer.user as { _id?: unknown })._id
+              : backer.user,
+          )
+        : undefined,
+    userName:
+      typeof backer.userName === 'string'
+        ? backer.userName
+        : backer.isAnonymous
+          ? '익명 후원자'
+          : '익명 후원자',
+    amount: toNumber(backer.amount),
+    date: toIsoString(backer.date ?? backer.backedAt),
+    status: typeof backer.status === 'string' ? backer.status : '완료',
+  }));
+};
+
+export const mapExecutionPlan = (
+  executionPlan: FundingProjectExecutionPlanPayload | undefined,
+  fallbackBudget: number,
+): ExecutionPlan => {
+  return {
+    stages: toArray(executionPlan?.stages).map(stage => ({
+      id: createId(stage.id ?? stage._id ?? stage.name, 'stage'),
+      name: typeof stage.name === 'string' ? stage.name : '',
+      description:
+        typeof stage.description === 'string' ? stage.description : '',
+      budget: toNumber(stage.budget),
+      startDate: toIsoString(stage.startDate),
+      endDate: toIsoString(stage.endDate),
+      status: typeof stage.status === 'string' ? stage.status : '계획',
+      progress: toNumber(stage.progress),
+    })),
+    totalBudget: toNumber(executionPlan?.totalBudget, fallbackBudget),
+  };
+};
+
+export const mapExpenseRecords = (
+  expenses?: FundingProjectPayload['expenseRecords'],
+): ExpenseRecord[] => {
+  return toArray<FundingProjectExpensePayload>(expenses).map(expense => ({
+    id: createId(expense.id ?? expense._id ?? expense.title, 'expense'),
+    category: typeof expense.category === 'string' ? expense.category : '',
+    title: typeof expense.title === 'string' ? expense.title : '',
+    description:
+      typeof expense.description === 'string' ? expense.description : '',
+    amount: toNumber(expense.amount),
+    date: toIsoString(expense.date),
+    receipt: typeof expense.receipt === 'string' ? expense.receipt : '',
+    stage: expense.stage ? String(expense.stage) : '',
+    verified: Boolean(expense.verified),
+  }));
+};
+
+export const mapRevenueDistribution = (
+  revenueDistribution: FundingProjectPayload['revenueDistribution'],
+  totalRevenue: number,
+): RevenueDistribution => {
+  return {
+    totalRevenue,
+    platformFee: mapRevenueShare(revenueDistribution?.platformFee, totalRevenue),
+    artistShare: mapRevenueShare(revenueDistribution?.artistShare, totalRevenue),
+    backerShare: mapRevenueShare(revenueDistribution?.backerShare, totalRevenue),
+    distributions: toArray<FundingProjectDistributionPayload>(
+      revenueDistribution?.distributions,
+    ).map(distribution => ({
+      id: createId(
+        distribution.id ?? distribution._id ?? distribution.backer,
+        'distribution',
+      ),
+      backer: distribution.backer
+        ? String(
+            typeof distribution.backer === 'object' &&
+            distribution.backer &&
+            '_id' in distribution.backer
+              ? (distribution.backer as { _id?: unknown })._id
+              : distribution.backer,
+          )
+        : undefined,
+      userName:
+        typeof distribution.userName === 'string'
+          ? distribution.userName
+          : '익명 후원자',
+      originalAmount: toNumber(distribution.originalAmount),
+      profitShare: toNumber(distribution.profitShare),
+      amount: toNumber(distribution.amount ?? distribution.totalReturn),
+      date: toIsoString(distribution.date ?? distribution.distributedAt),
+      status:
+        typeof distribution.status === 'string'
+          ? distribution.status
+          : '대기',
+    })),
+  };
+};
+
+export const mapFundingProjectDetail = (
+  project: FundingProjectPayload | null | undefined,
+): FundingProject | null => {
+  if (!project) {
+    return null;
+  }
+
+  const goalAmount = toNumber(project.goalAmount, toNumber(project.targetAmount));
+  const targetAmount = toNumber(project.targetAmount, goalAmount);
+  const currentAmount = toNumber(project.currentAmount);
+  const totalRevenue = toNumber(
+    project.revenueDistribution?.totalRevenue,
+    currentAmount,
+  );
+
+  const backerCount =
+    typeof project.backers === 'number'
+      ? project.backers
+      : Array.isArray(project.backers)
+        ? project.backers.length
+        : Array.isArray(project.backersList)
+          ? project.backersList.filter((item): item is unknown => item != null)
+              .length
+          : 0;
+
+  const artistName =
+    typeof project.artist === 'string'
+      ? project.artist
+      : project.artist && typeof project.artist === 'object'
+        ? typeof (project.artist as { name?: unknown }).name === 'string'
+          ? (project.artist as { name: string }).name
+          : typeof project.artistName === 'string'
+            ? project.artistName
+            : ''
+        : typeof project.artistName === 'string'
+          ? project.artistName
+          : '';
+
+  return {
+    id: createId(project.id ?? project._id, 'project'),
+    title: typeof project.title === 'string' ? project.title : '',
+    description:
+      typeof project.description === 'string' ? project.description : '',
+    artist: artistName,
+    category: typeof project.category === 'string' ? project.category : '',
+    goalAmount,
+    targetAmount,
+    currentAmount,
+    backers: backerCount,
+    daysLeft: toNumber(project.daysLeft),
+    image: typeof project.image === 'string' ? project.image : '',
+    status: typeof project.status === 'string' ? project.status : '',
+    progressPercentage: toNumber(
+      project.progressPercentage,
+      toNumber(project.progress),
+    ),
+    startDate: toIsoString(project.startDate),
+    endDate: toIsoString(project.endDate),
+    story:
+      typeof project.story === 'string'
+        ? project.story
+        : typeof project.description === 'string'
+          ? project.description
+          : undefined,
+    artistAvatar:
+      typeof project.artistAvatar === 'string' ? project.artistAvatar : undefined,
+    artistRating:
+      typeof project.artistRating === 'number' ? project.artistRating : undefined,
+    artistId: project.artistId
+      ? String(project.artistId)
+      : project.artist &&
+          typeof project.artist === 'object' &&
+          project.artist !== null &&
+          '_id' in project.artist
+        ? String((project.artist as { _id?: unknown })._id)
+        : undefined,
+    featured:
+      typeof project.featured === 'boolean' ? project.featured : undefined,
+    rewards: mapRewards(project.rewards),
+    updates: mapUpdates(project.updates),
+    backersList: mapBackers({
+      backers: project.backers,
+      backersList: project.backersList,
+    }),
+    executionPlan: mapExecutionPlan(project.executionPlan, goalAmount),
+    expenseRecords: mapExpenseRecords(project.expenseRecords),
+    revenueDistribution: mapRevenueDistribution(
+      project.revenueDistribution,
+      totalRevenue,
+    ),
+  };
+};
+
+export type { FundingProjectPayload };

--- a/src/types/fundingProject.ts
+++ b/src/types/fundingProject.ts
@@ -3,11 +3,11 @@
 export interface FundingProject {
   id: string;
   title: string;
-  description?: string;
+  description: string;
   artist: string;
   category: string;
   goalAmount: number;
-  targetAmount?: number;
+  targetAmount: number;
   currentAmount: number;
   backers: number;
   daysLeft: number;
@@ -107,4 +107,139 @@ export interface RevenueDistribution {
   artistShare: RevenueShare;
   backerShare: RevenueShare;
   distributions: Distribution[];
+}
+
+export interface FundingProjectRewardPayload {
+  id?: string | number;
+  _id?: string | number;
+  title?: string;
+  description?: string;
+  amount?: number | string;
+  estimatedDelivery?: string | Date;
+  claimed?: number | string;
+  maxClaim?: number | string;
+}
+
+export interface FundingProjectUpdatePayload {
+  id?: string | number;
+  _id?: string | number;
+  title?: string;
+  content?: string;
+  date?: string | Date;
+  createdAt?: string | Date;
+  type?: string;
+}
+
+export interface FundingProjectBackerPayload {
+  id?: string | number;
+  _id?: string | number;
+  userId?: string | number;
+  user?: string | number | { _id?: string | number };
+  userName?: string;
+  isAnonymous?: boolean;
+  amount?: number | string;
+  date?: string | Date;
+  backedAt?: string | Date;
+  status?: string;
+}
+
+export interface FundingProjectExecutionStagePayload {
+  id?: string | number;
+  _id?: string | number;
+  name?: string;
+  description?: string;
+  budget?: number | string;
+  startDate?: string | Date;
+  endDate?: string | Date;
+  status?: string;
+  progress?: number | string;
+}
+
+export interface FundingProjectExecutionPlanPayload {
+  stages?: (FundingProjectExecutionStagePayload | null | undefined)[];
+  totalBudget?: number | string;
+}
+
+export interface FundingProjectExpensePayload {
+  id?: string | number;
+  _id?: string | number;
+  category?: string;
+  title?: string;
+  description?: string;
+  amount?: number | string;
+  date?: string | Date;
+  receipt?: string;
+  stage?: string | number;
+  verified?: boolean;
+}
+
+export interface FundingProjectDistributionPayload {
+  id?: string | number;
+  _id?: string | number;
+  backer?: string | number | { _id?: string | number };
+  userName?: string;
+  originalAmount?: number | string;
+  profitShare?: number | string;
+  amount?: number | string;
+  totalReturn?: number | string;
+  date?: string | Date;
+  distributedAt?: string | Date;
+  status?: string;
+}
+
+export type RevenueSharePayload =
+  | FundingProjectRevenueShareObjectPayload
+  | number
+  | string
+  | null
+  | undefined;
+
+export interface FundingProjectRevenueShareObjectPayload {
+  amount?: number | string;
+  percentage?: number | string;
+}
+
+export interface FundingProjectRevenueDistributionPayload {
+  totalRevenue?: number | string;
+  platformFee?: RevenueSharePayload;
+  artistShare?: RevenueSharePayload;
+  backerShare?: RevenueSharePayload;
+  distributions?: (FundingProjectDistributionPayload | null | undefined)[];
+}
+
+export interface FundingProjectPayload {
+  id?: string | number;
+  _id?: string | number;
+  title?: string;
+  description?: string;
+  artist?:
+    | string
+    | {
+        _id?: string | number;
+        name?: string;
+      };
+  artistName?: string;
+  category?: string;
+  goalAmount?: number | string;
+  targetAmount?: number | string;
+  currentAmount?: number | string;
+  backers?: number | FundingProjectBackerPayload[];
+  backersList?: (FundingProjectBackerPayload | null | undefined)[];
+  daysLeft?: number | string;
+  image?: string;
+  status?: string;
+  progressPercentage?: number | string;
+  progress?: number | string;
+  startDate?: string | Date;
+  endDate?: string | Date;
+  story?: string;
+  artistAvatar?: string;
+  artistRating?: number;
+  artistId?: string | number;
+  featured?: boolean;
+  rewards?: (FundingProjectRewardPayload | null | undefined)[];
+  updates?: (FundingProjectUpdatePayload | null | undefined)[];
+  executionPlan?: FundingProjectExecutionPlanPayload;
+  expenseRecords?: (FundingProjectExpensePayload | null | undefined)[];
+  revenueDistribution?: FundingProjectRevenueDistributionPayload;
 }


### PR DESCRIPTION
## Summary
- extract the funding project normalization utilities into a dedicated mapper module and expose typed helper mappers
- tighten the funding project TypeScript contracts to describe both API payloads and the normalized shape used by the UI
- wire the funding API service to the new mapper and cover representative payload variants with unit tests

## Testing
- npm test -- fundingProjectMapper *(fails: `jest` binary unavailable because `npm install` is blocked by registry 403 for `dotenv`)*

------
https://chatgpt.com/codex/tasks/task_b_68d155c8fa7483268dce4ad31770c6d1