### PR TITLE
fix: normalize funding goal and stage budgets

### DIFF
--- a/server/routes/funding.js
+++ b/server/routes/funding.js
@@ -101,6 +101,8 @@ router.post('/projects', auth, async (req, res) => {
       executionPlan,
     } = req.body;
 
+    const goalAmountValue = Number(goalAmount);
+
     // 필수 필드 검증
     if (
       !title ||
@@ -117,7 +119,7 @@ router.post('/projects', auth, async (req, res) => {
     }
 
     // 금액 유효성 검증
-    if (goalAmount < 100000) {
+    if (goalAmountValue < 100000) {
       return res.status(400).json({
         success: false,
         message: '목표 금액은 10만원 이상이어야 합니다.',
@@ -155,10 +157,10 @@ router.post('/projects', auth, async (req, res) => {
     // 집행 계획 검증
     if (executionPlan && executionPlan.stages) {
       const totalBudget = executionPlan.stages.reduce(
-        (sum, stage) => sum + stage.budget,
+        (sum, stage) => sum + Number(stage.budget || 0),
         0,
       );
-      if (totalBudget !== goalAmount) {
+      if (totalBudget !== goalAmountValue) {
         return res.status(400).json({
           success: false,
           message: '집행 계획의 총 예산이 목표 금액과 일치해야 합니다.',
@@ -171,12 +173,13 @@ router.post('/projects', auth, async (req, res) => {
       title,
       description,
       category,
-      goalAmount: parseInt(goalAmount),
+      goalAmount: goalAmountValue,
       startDate: start,
       endDate: end,
       rewards: rewards || [],
       tags: tags || [],
-      executionPlan: executionPlan || { stages: [], totalBudget: goalAmount },
+      executionPlan:
+        executionPlan || { stages: [], totalBudget: goalAmountValue },
       artist: req.user.id,
       artistName: req.user.name,
       status: '준비중',
@@ -565,7 +568,7 @@ router.put('/projects/:id/execution', auth, async (req, res) => {
     // 집행 계획 업데이트
     project.executionPlan.stages = stages;
     project.executionPlan.totalBudget = stages.reduce(
-      (sum, stage) => sum + stage.budget,
+      (sum, stage) => sum + Number(stage.budget || 0),
       0,
     );
     project.status = '집행중';

--- a/server/tests/routes/funding.create.test.js
+++ b/server/tests/routes/funding.create.test.js
@@ -1,0 +1,125 @@
+const express = require('express');
+const request = require('supertest');
+
+let authenticatedUser;
+const savedProjects = [];
+
+jest.mock('../../middleware/auth', () => {
+  return (req, res, next) => {
+    if (!authenticatedUser) {
+      return res.status(401).json({
+        message: '인증 토큰이 필요합니다',
+      });
+    }
+
+    req.user = authenticatedUser;
+    return next();
+  };
+});
+
+jest.mock('../../models/FundingProject', () => {
+  class FundingProjectMock {
+    constructor(data) {
+      Object.assign(this, data);
+      this._id = `mock-project-${FundingProjectMock._counter++}`;
+    }
+
+    async save() {
+      savedProjects.push({ ...this });
+    }
+
+    static findById(id) {
+      const project = savedProjects.find(item => item._id === id) || {};
+      return {
+        populate: () => ({
+          lean: () =>
+            Promise.resolve({
+              _id: id,
+              ...project,
+              daysLeft: project.daysLeft ?? 0,
+            }),
+        }),
+      };
+    }
+
+    static __reset() {
+      savedProjects.length = 0;
+      FundingProjectMock._counter = 1;
+    }
+
+    static __getSavedProjects() {
+      return savedProjects;
+    }
+  }
+
+  FundingProjectMock._counter = 1;
+
+  return FundingProjectMock;
+});
+
+const FundingProject = require('../../models/FundingProject');
+const fundingRouter = require('../../routes/funding');
+
+describe('POST /api/funding/projects - string budget handling', () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/funding', fundingRouter);
+  });
+
+  beforeEach(() => {
+    authenticatedUser = {
+      id: 'artist-1',
+      name: '테스트 아티스트',
+      role: 'artist',
+    };
+    FundingProject.__reset();
+  });
+
+  afterEach(() => {
+    authenticatedUser = null;
+  });
+
+  it('accepts string budgets when the total matches the goal amount', async () => {
+    const now = Date.now();
+    const startDate = new Date(now + 24 * 60 * 60 * 1000);
+    const stageEndDate = new Date(now + 4 * 24 * 60 * 60 * 1000);
+    const endDate = new Date(now + 14 * 24 * 60 * 60 * 1000);
+
+    const response = await request(app)
+      .post('/api/funding/projects')
+      .send({
+        title: '문자열 예산 프로젝트',
+        description: '집행 단계 예산이 문자열로 전달되는 경우를 검증합니다.',
+        category: '음악',
+        goalAmount: '300000',
+        startDate: startDate.toISOString(),
+        endDate: endDate.toISOString(),
+        executionPlan: {
+          stages: [
+            {
+              name: '준비 단계',
+              description: '사전 준비를 위한 단계',
+              budget: '100000',
+              startDate: startDate.toISOString(),
+              endDate: stageEndDate.toISOString(),
+            },
+            {
+              name: '실행 단계',
+              description: '본격적인 프로젝트 실행',
+              budget: '200000',
+              startDate: stageEndDate.toISOString(),
+              endDate: endDate.toISOString(),
+            },
+          ],
+          totalBudget: '300000',
+        },
+      });
+
+    expect(response.status).toBe(201);
+    expect(response.body.success).toBe(true);
+    expect(response.body.message).toContain('펀딩 프로젝트가 성공적으로 시작되었습니다');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure funding project creation uses a numeric goal amount and coerce stage budgets before validation
- coerce execution stage budgets when updating execution plans to keep totals accurate
- add a server test that covers string-based stage budgets summing to the goal amount

## Testing
- npm test -- funding.create.test.js

------
https://chatgpt.com/codex/tasks/task_b_68d155e469e08326bac553baaf778a0f