### PR TITLE
feat: refactor community post detail view

### DIFF
--- a/src/components/CommunityPostDetail.tsx
+++ b/src/components/CommunityPostDetail.tsx
@@ -1,1047 +1,189 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Button } from '../shared/ui/Button';
-import { Input } from './ui/input';
-import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
-import { Badge } from './ui/badge';
-import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
-import { useAuth } from '../contexts/AuthContext';
-import { communityPostAPI } from '../services/api/community';
-import { ApiResponse } from '../types';
-import { useDeleteCommunityPost } from '../features/community/hooks/useCommunityPosts';
-import {
-  usePostReaction,
-} from '../lib/api/useCommunityReactions';
-import {
-  useCreateComment,
-  useDeleteComment,
-  useCreateReply,
-} from '../lib/api/useCommunityComments';
-import { useAuthRedirect } from '../hooks/useAuthRedirect';
-import {
-  ArrowLeft,
-  Heart,
-  MessageCircle,
-  Eye,
-  Trash2,
-  MoreVertical,
-  Copy,
-  Share2,
-} from 'lucide-react';
-import { formatDistanceToNow } from 'date-fns';
-import { ko } from 'date-fns/locale';
-import { getFirstChar, getUsername } from '../utils/typeGuards';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from './ui/dropdown-menu';
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from './ui/alert-dialog';
+import { FC } from 'react';
+import { ArrowLeft } from 'lucide-react';
 
-// 댓글 데이터 변환 함수 (컴포넌트 외부로 이동)
-const transformComments = (comments: any[]): Comment[] => {
-  if (!Array.isArray(comments)) return [];
-
-  return comments
-    .filter((comment: any) => comment && typeof comment === 'object') // 유효한 객체만 필터링
-    .map((comment: any) => {
-      try {
-        // 안전한 날짜 처리
-        let createdAt: Date;
-        try {
-          createdAt = new Date(comment.createdAt);
-          if (isNaN(createdAt.getTime())) {
-            createdAt = new Date();
-          }
-        } catch {
-          createdAt = new Date();
-        }
-
-        return {
-          id: String(comment.id || comment._id || ''),
-          author:
-            typeof comment.author === 'string'
-              ? comment.author
-              : comment.author?.name ||
-                comment.author?.username ||
-                comment.authorName ||
-                'Unknown',
-          authorId: String(
-            comment.authorId ||
-              (typeof comment.author === 'string'
-                ? comment.author
-                : comment.author?.id) ||
-              comment.authorName ||
-              '',
-          ),
-          content: String(comment.content || ''),
-          timeAgo:
-            comment.timeAgo ||
-            formatDistanceToNow(createdAt, { addSuffix: true, locale: ko }),
-          createdAt: createdAt,
-          replies: Array.isArray(comment.replies)
-            ? transformComments(comment.replies)
-            : [],
-          parentId: comment.parentId ? String(comment.parentId) : undefined,
-        };
-      } catch (error) {
-        console.error('댓글 변환 중 오류:', error, comment);
-        // 오류 발생 시 기본값 반환
-        return {
-          id: String(comment.id || comment._id || ''),
-          author: 'Unknown',
-          authorId: '',
-          content: String(comment.content || ''),
-          timeAgo: '방금 전',
-          createdAt: new Date(),
-          replies: [],
-          parentId: undefined,
-        };
-      }
-    });
-};
-
-interface Comment {
-  id: string;
-  author: string;
-  authorId: string;
-  content: string;
-  timeAgo: string;
-  createdAt: Date;
-  replies?: Comment[]; // 대댓글 배열
-  parentId?: string; // 부모 댓글 ID (대댓글인 경우)
-}
-
-interface PostDetail {
-  id: string;
-  title: string;
-  category: string;
-  author: string;
-  authorId: string;
-  content: string;
-  images: string[];
-  timeAgo: string;
-  replies: number;
-  likes: number;
-  dislikes: number;
-  isLiked: boolean;
-  isDisliked: boolean;
-  isHot: boolean;
-  viewCount: number;
-  views: number;
-  createdAt: Date;
-  updatedAt: Date;
-  comments: Comment[];
-}
+import { Button } from '@/shared/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/AuthContext';
+import { CommentComposer } from '@/features/community/components/CommentComposer';
+import { CommentThread } from '@/features/community/components/CommentThread';
+import { DeletePostDialog } from '@/features/community/components/DeletePostDialog';
+import { PostHeader } from '@/features/community/components/PostHeader';
+import { ReactionBar } from '@/features/community/components/ReactionBar';
+import { useCommunityPostDetail } from '@/features/community/hooks/useCommunityPostDetail';
 
 interface CommunityPostDetailProps {
   postId: string;
   onBack?: () => void;
 }
 
-export const CommunityPostDetail: React.FC<CommunityPostDetailProps> = ({
+export const CommunityPostDetail: FC<CommunityPostDetailProps> = ({
   postId,
   onBack,
 }) => {
   const { user } = useAuth();
-  const { requireAuth } = useAuthRedirect();
-  const deletePostMutation = useDeleteCommunityPost();
-  const postReactionMutation = usePostReaction();
-  const createCommentMutation = useCreateComment();
-  const deleteCommentMutation = useDeleteComment();
-  const createReplyMutation = useCreateReply();
-  const [post, setPost] = useState<PostDetail | null>(null);
-  const [comment, setComment] = useState('');
-  const [isLoading, setIsLoading] = useState(true);
-  // React Query 훅의 로딩 상태 사용
-  const isLiking = postReactionMutation.isPending;
-  const isDisliking = postReactionMutation.isPending;
-  const isSubmittingComment = createCommentMutation.isPending;
-  const isSubmittingReply = createReplyMutation.isPending;
-  const [error, setError] = useState('');
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const {
+    post,
+    isLoading,
+    error,
+    state: { comment, replyingTo, replyContent, copiedLink, showDeleteDialog },
+    status: {
+      isLiked,
+      isDisliked,
+      isLiking,
+      isDisliking,
+      isSubmittingComment,
+      isSubmittingReply,
+      isDeletingPost,
+    },
+    setComment,
+    setReplyingTo,
+    setReplyContent,
+    setShowDeleteDialog,
+    actions: {
+      handleBack,
+      handleCopyLink,
+      handleSocialShare,
+      handleLike,
+      handleDislike,
+      handleCommentSubmit,
+      handleCommentDelete,
+      handleReplySubmit,
+      cancelReply,
+      handleDeletePost,
+    },
+    permissions: { canDeleteComment, canDeletePost },
+  } = useCommunityPostDetail(postId, { onBack });
 
-  // 대댓글 관련 상태
-  const [replyingTo, setReplyingTo] = useState<string | null>(null);
-  const [replyContent, setReplyContent] = useState('');
-  const [copiedLink, setCopiedLink] = useState(false);
-
-  // 링크 복사 기능
-  const handleCopyLink = async () => {
-    const link = `${window.location.origin}/community/post/${postId}`;
-    try {
-      await navigator.clipboard.writeText(link);
-      setCopiedLink(true);
-      setTimeout(() => setCopiedLink(false), 2000);
-    } catch (error) {
-      console.error('링크 복사 실패:', error);
-    }
-  };
-
-  // 소셜 공유 기능
-  const handleSocialShare = (platform: 'twitter' | 'facebook' | 'kakao') => {
-    const link = `${window.location.origin}/community/post/${postId}`;
-    const title = post?.title || '게시글';
-
-    switch (platform) {
-      case 'twitter':
-        window.open(
-          `https://twitter.com/intent/tweet?text=${encodeURIComponent(title)}&url=${encodeURIComponent(link)}`,
-          '_blank',
-        );
-        break;
-      case 'facebook':
-        window.open(
-          `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(link)}`,
-          '_blank',
-        );
-        break;
-      case 'kakao':
-        // 카카오톡 공유는 Kakao SDK가 필요하므로 기본 링크 복사로 대체
-        handleCopyLink();
-        break;
-    }
-  };
-
-  const fetchPostDetail = useCallback(async () => {
-    if (!postId || postId === 'undefined') {
-      setError('유효하지 않은 게시글 ID입니다.');
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      setIsLoading(true);
-      const response = await communityPostAPI.getPost(postId);
-      const postData =
-        response && typeof response === 'object' && 'data' in response
-          ? (response as { data: PostDetail | null }).data
-          : (response as PostDetail | null);
-
-      if (postData && typeof postData === 'object') {
-        // 댓글 데이터를 안전하게 변환
-        let transformedComments: Comment[] = [];
-
-        if (postData.comments) {
-          if (Array.isArray(postData.comments)) {
-            try {
-              transformedComments = transformComments(postData.comments);
-            } catch (error) {
-              console.error('댓글 변환 오류:', error);
-              transformedComments = [];
-            }
-          } else {
-            console.warn(
-              '댓글 데이터가 배열이 아닙니다:',
-              typeof postData.comments,
-            );
-            transformedComments = [];
-          }
-        }
-
-        const formattedPost: PostDetail = {
-          id: postData.id || (postData as any)._id || postId, // _id를 id로 매핑
-          title: postData.title || '',
-          category: postData.category || '',
-          author:
-            typeof postData.author === 'string'
-              ? postData.author
-              : (postData.author as any)?.name || 'Unknown',
-          authorId:
-            typeof postData.author === 'string'
-              ? postData.author
-              : (postData.author as any)?.id || postData.author,
-          content: postData.content || '',
-          images: Array.isArray(postData.images) ? postData.images : [],
-          timeAgo: formatDistanceToNow(new Date(postData.createdAt), {
-            addSuffix: true,
-            locale: ko,
-          }),
-          replies: postData.replies || 0,
-          likes: Array.isArray(postData.likes)
-            ? postData.likes.length
-            : postData.likes || 0,
-          dislikes: Array.isArray(postData.dislikes)
-            ? postData.dislikes.length
-            : postData.dislikes || 0,
-          isLiked: false,
-          isDisliked: false,
-          isHot:
-            (Array.isArray(postData.likes)
-              ? postData.likes.length
-              : postData.likes || 0) > 20,
-          viewCount: postData.views || postData.viewCount || 0,
-          views: postData.views || postData.viewCount || 0,
-          createdAt: new Date(postData.createdAt),
-          updatedAt: new Date(postData.updatedAt),
-          comments: transformedComments,
-        };
-        setPost(formattedPost);
-        setError('');
-
-        // 사용자별 반응 상태 확인은 별도 useEffect에서 처리
-      } else {
-        setError('포스트를 불러올 수 없습니다.');
-        setPost(null);
-      }
-    } catch (error) {
-      console.error('포스트 상세 조회 오류:', error);
-
-      // 에러 타입에 따른 메시지 설정
-      let errorMessage = '포스트 조회 중 오류가 발생했습니다.';
-      if (error instanceof Error) {
-        if (error.message.includes('서버 리소스가 부족합니다')) {
-          errorMessage =
-            '서버가 일시적으로 과부하 상태입니다. 잠시 후 다시 시도해주세요.';
-        } else if (error.message.includes('요청 시간이 초과되었습니다')) {
-          errorMessage =
-            '요청 시간이 초과되었습니다. 네트워크 연결을 확인해주세요.';
-        } else if (error.message.includes('Failed to fetch')) {
-          errorMessage =
-            '네트워크 연결에 문제가 있습니다. 인터넷 연결을 확인해주세요.';
-        }
-      }
-
-      setPost(null);
-      setError(errorMessage);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [postId]); // user 의존성 제거
-
-  const handleLike = () => {
-    requireAuth(() => {
-      if (!user || !post) return;
-
-      // 이미 좋아요가 되어 있다면 취소, 아니면 좋아요
-      const action = post.isLiked ? 'unlike' : 'like';
-
-      postReactionMutation.mutate(
-        { postId, reaction: action },
-        {
-          onSuccess: (data: any) => {
-            // 서버에서 반환된 상태로 업데이트
-            setPost((prev: any) =>
-              prev
-                ? {
-                    ...prev,
-                    likes: data.likes,
-                    dislikes: data.dislikes,
-                    isLiked: data.isLiked,
-                    isDisliked: data.isDisliked,
-                    isHot: data.likes > 20,
-                  }
-                : null,
-            );
-          },
-          onError: error => {
-            console.error('좋아요 처리 오류:', error);
-          },
-        },
-      );
-    });
-  };
-
-  const handleDislike = () => {
-    requireAuth(() => {
-      if (!user || !post) return;
-
-      // 이미 싫어요가 되어 있다면 취소, 아니면 싫어요
-      const action = post.isDisliked ? 'undislike' : 'dislike';
-
-      postReactionMutation.mutate(
-        { postId, reaction: action },
-        {
-          onSuccess: (data: any) => {
-            // 서버에서 반환된 상태로 업데이트
-            setPost((prev: any) =>
-              prev
-                ? {
-                    ...prev,
-                    likes: data.likes,
-                    dislikes: data.dislikes,
-                    isLiked: data.isLiked,
-                    isDisliked: data.isDisliked,
-                  }
-                : null,
-            );
-          },
-          onError: error => {
-            console.error('싫어요 처리 오류:', error);
-          },
-        },
-      );
-    });
-  };
-
-  const handleCommentSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!comment.trim() || !post) return;
-
-    requireAuth(() => {
-      if (!user) return;
-
-      createCommentMutation.mutate(
-        { postId, content: comment.trim() },
-        {
-          onSuccess: () => {
-            setComment('');
-            // 댓글 목록 새로고침은 훅에서 자동 처리
-          },
-          onError: error => {
-            console.error('댓글 작성 실패:', error);
-          },
-        },
-      );
-    });
-  };
-
-  const handleCommentDelete = (commentId: string) => {
-    requireAuth(() => {
-      if (!user || !post) return;
-
-      deleteCommentMutation.mutate(
-        { postId, commentId },
-        {
-          onSuccess: () => {
-            // 댓글 목록 새로고침은 훅에서 자동 처리
-          },
-          onError: error => {
-            console.error('댓글 삭제 실패:', error);
-          },
-        },
-      );
-    });
-  };
-
-  // 대댓글 작성 함수
-  const handleReplySubmit = (e: React.FormEvent, parentCommentId: string) => {
-    e.preventDefault();
-    if (!replyContent.trim() || !post) return;
-
-    requireAuth(() => {
-      if (!user) return;
-
-      createReplyMutation.mutate(
-        { postId, parentCommentId, content: replyContent.trim() },
-        {
-          onSuccess: () => {
-            setReplyContent('');
-            setReplyingTo(null);
-            // 댓글 목록 새로고침은 훅에서 자동 처리
-          },
-          onError: error => {
-            console.error('대댓글 작성 실패:', error);
-          },
-        },
-      );
-    });
-  };
-
-  // 대댓글 작성 취소
-  const cancelReply = () => {
-    setReplyingTo(null);
-    setReplyContent('');
-  };
-
-  // 대댓글 표시 함수
-  const renderReplies = (replies: Comment[] = []) => {
-    if (!Array.isArray(replies) || replies.length === 0) return null;
-
-    return (
-      <div className='ml-8 mt-3 space-y-3 border-l-2 border-gray-200 pl-4'>
-        {replies.map(reply => {
-          // reply가 유효한 객체인지 확인
-          if (!reply || typeof reply !== 'object' || !reply.id) {
-            return null;
-          }
-
-          return (
-            <div
-              key={reply.id}
-              className='flex gap-3 rounded-lg bg-gray-100 p-3'
-            >
-              <Avatar className='h-8 w-8'>
-                <AvatarFallback>
-                  {getFirstChar(reply.author || 'U')}
-                </AvatarFallback>
-              </Avatar>
-              <div className='flex-1'>
-                <div className='mb-2 flex items-center justify-between'>
-                  <div className='flex items-center gap-2'>
-                    <span className='text-sm font-medium'>
-                      {typeof reply.author === 'string'
-                        ? reply.author
-                        : (reply.author as any)?.name || 'Unknown'}
-                    </span>
-                    <span className='text-xs text-gray-500'>
-                      {reply.timeAgo || '방금 전'}
-                    </span>
-                  </div>
-                  {canDeleteComment(reply.authorId || '') && (
-                    <Button
-                      variant='ghost'
-                      size='sm'
-                      onClick={() => handleCommentDelete(reply.id)}
-                      className='h-auto p-1 text-red-500 hover:text-red-700'
-                    >
-                      <Trash2 className='h-3 w-3' />
-                    </Button>
-                  )}
-                </div>
-                <p className='text-sm text-gray-700'>{reply.content || ''}</p>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-    );
-  };
-
-  const canDeleteComment = (commentAuthorId: string) => {
-    return user && (user.id === commentAuthorId || user.id === post?.authorId);
-  };
-
-  const canDeletePost = () => {
-    return user && post && (user.id === post.authorId || user.role === 'admin');
-  };
-
-  const handleDeletePost = async () => {
-    if (!user || !post) return;
-
-    try {
-      await deletePostMutation.mutateAsync(postId);
-      // 삭제 성공 시 목록으로 돌아가기
-      handleBack();
-    } catch (error) {
-      console.error('게시글 삭제 오류:', error);
-      setError('게시글 삭제 중 오류가 발생했습니다.');
-    } finally {
-      setShowDeleteDialog(false);
-    }
-  };
-
-  // 이전 페이지로 돌아가기
-  const handleBack = useCallback(() => {
-    if (onBack) {
-      onBack();
-    } else {
-      // 더 확실한 뒤로가기 방법
-      try {
-        // 세션 스토리지에서 이전 페이지 정보 확인
-        const previousPage = sessionStorage.getItem('previousPage');
-
-        if (previousPage && previousPage !== window.location.href) {
-          // 이전 페이지로 이동
-          window.location.href = previousPage;
-        } else if (window.history.length > 1) {
-          // 브라우저 히스토리에서 이전 페이지로 이동
-          window.history.back();
-        } else {
-          // 모두 실패하면 홈으로 이동
-          window.location.href = '/';
-        }
-      } catch (error) {
-        console.error('뒤로가기 실패:', error);
-        // 에러 발생 시 홈으로 이동
-        window.location.href = '/';
-      }
-    }
-  }, [onBack]);
-
-  useEffect(() => {
-    // postId가 유효하지 않은 경우 처리
-    if (!postId || postId === 'undefined') {
-      setError('유효하지 않은 게시글 ID입니다.');
-      setIsLoading(false);
-      return;
-    }
-
-    // 현재 페이지 정보를 세션 스토리지에 저장
-    const currentPage = window.location.href;
-    const previousPage = sessionStorage.getItem('currentPage');
-
-    if (previousPage && previousPage !== currentPage) {
-      sessionStorage.setItem('previousPage', previousPage);
-    }
-
-    sessionStorage.setItem('currentPage', currentPage);
-
-    fetchPostDetail();
-
-    // 브라우저 뒤로가기 버튼 처리
-    const handlePopState = () => {
-      handleBack();
-    };
-
-    window.addEventListener('popstate', handlePopState);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, [postId]); // 의존성 배열에서 함수들 제거
-
-  // 사용자 반응 상태 확인을 위한 별도 useEffect
-  useEffect(() => {
-    if (user && post?.id) {
-      communityPostAPI
-        .getPostReactions(post.id)
-        .then((reactionsResponse: unknown) => {
-          // raw payload를 직접 처리 (response.success 체크 제거)
-          const data = reactionsResponse as any;
-          setPost((prev: any) =>
-            prev
-              ? {
-                  ...prev,
-                  isLiked: data?.isLiked || false,
-                  isDisliked: data?.isDisliked || false,
-                  likes: data?.likes || prev.likes,
-                  dislikes: data?.dislikes || prev.dislikes,
-                }
-              : null,
-          );
-        })
-        .catch(err => {
-          console.error('반응 상태 확인 실패:', err);
-          // 반응 상태 확인 실패 시에도 기본값으로 설정
-          setPost((prev: any) =>
-            prev
-              ? {
-                  ...prev,
-                  isLiked: false,
-                  isDisliked: false,
-                }
-              : null,
-          );
-        });
-    }
-  }, [user, post?.id]);
+  const handleCommentChange = (value: string) => setComment(value);
+  const handleReplyChange = (value: string) => setReplyContent(value);
+  const handleStartReply = (commentId: string) => setReplyingTo(commentId);
 
   if (isLoading) {
     return (
       <div className='flex min-h-screen items-center justify-center bg-gray-50'>
-        <div className='text-center'>
-          <div className='mx-auto h-12 w-12 animate-spin rounded-full border-b-2 border-blue-600'></div>
-          <p className='mt-4 text-gray-600'>포스트를 불러오는 중...</p>
-        </div>
+        <span className='text-gray-500'>게시글을 불러오는 중입니다...</span>
       </div>
     );
   }
 
-  if (error || !post) {
+  if (error) {
     return (
       <div className='flex min-h-screen items-center justify-center bg-gray-50'>
-        <div className='text-center'>
-          <div className='mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100'>
-            <svg
-              className='h-8 w-8 text-red-600'
-              fill='none'
-              stroke='currentColor'
-              viewBox='0 0 24 24'
-            >
-              <path
-                strokeLinecap='round'
-                strokeLinejoin='round'
-                strokeWidth={2}
-                d='M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z'
-              />
-            </svg>
-          </div>
-          <h2 className='mb-2 text-xl font-semibold text-gray-900'>
-            오류가 발생했습니다
-          </h2>
-          <p className='mb-4 text-gray-600'>
-            {error || '포스트를 찾을 수 없습니다.'}
-          </p>
-          <div className='flex justify-center gap-3'>
-            <Button onClick={fetchPostDetail} variant='outline'>
-              🔄 다시 시도
-            </Button>
-            <Button onClick={handleBack} variant='outline'>
-              ← 목록으로 돌아가기
-            </Button>
-          </div>
+        <div className='space-y-4 text-center'>
+          <p className='text-gray-600'>{error}</p>
+          <Button onClick={handleBack} variant='outline'>
+            <ArrowLeft className='mr-2 h-4 w-4' /> 뒤로 가기
+          </Button>
         </div>
       </div>
     );
   }
 
-  const isLiked = post.isLiked;
-  const isDisliked = post.isDisliked;
+  if (!post) {
+    return (
+      <div className='flex min-h-screen items-center justify-center bg-gray-50'>
+        <div className='space-y-4 text-center'>
+          <p className='text-gray-600'>게시글 정보를 찾을 수 없습니다.</p>
+          <Button onClick={handleBack} variant='outline'>
+            <ArrowLeft className='mr-2 h-4 w-4' /> 뒤로 가기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const commentsCount =
+    typeof post.replies === 'number' ? post.replies : post.comments.length;
 
   return (
     <div className='min-h-screen bg-gray-50 py-8'>
       <div className='mx-auto max-w-4xl px-4'>
-        {/* 헤더 */}
-        <div className='mb-6'>
-          <Button onClick={handleBack} variant='outline' className='mb-4'>
-            <ArrowLeft className='mr-2 h-4 w-4' />
-            이전 페이지로 돌아가기
-          </Button>
+        <Button onClick={handleBack} variant='outline' className='mb-4'>
+          <ArrowLeft className='mr-2 h-4 w-4' />
+          이전 페이지로 돌아가기
+        </Button>
 
-          <Card>
-            <CardHeader>
-              <div className='flex items-start justify-between'>
-                <div className='flex-1'>
-                  <div className='mb-3 flex items-center gap-2'>
-                    <Badge variant='secondary'>{post.category}</Badge>
-                    {post.isHot && <Badge variant='destructive'>HOT</Badge>}
-                  </div>
-                  <CardTitle className='mb-2 text-2xl'>
-                    {post.title || '제목 없음'}
-                  </CardTitle>
-                  <div className='flex items-center gap-4 text-sm text-gray-500'>
-                    <span>작성자: {getUsername(post.author)}</span>
-                    <span>{post.timeAgo}</span>
-                    <span className='flex items-center gap-1'>
-                      <Eye className='h-4 w-4' />
-                      {post.viewCount}
-                    </span>
-                  </div>
-                </div>
-
-                {/* 액션 버튼들 */}
-                <div className='flex items-center gap-2'>
-                  {/* 링크 복사 버튼 */}
-                  <Button
-                    variant='ghost'
-                    size='sm'
-                    onClick={handleCopyLink}
-                    className='h-8 px-3'
-                  >
-                    {copiedLink ? (
-                      <div className='flex items-center gap-1 text-green-600'>
-                        <div className='h-2 w-2 rounded-full bg-green-600'></div>
-                        복사됨
-                      </div>
-                    ) : (
-                      <div className='flex items-center gap-1'>
-                        <Copy className='h-4 w-4' />
-                        링크 복사
-                      </div>
-                    )}
-                  </Button>
-
-                  {/* 소셜 공유 메뉴 */}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant='ghost' size='sm' className='h-8 px-3'>
-                        <Share2 className='mr-1 h-4 w-4' />
-                        공유
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align='end'>
-                      <DropdownMenuItem
-                        onClick={() => handleSocialShare('twitter')}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <div className='h-4 w-4 rounded bg-blue-500'></div>
-                          트위터
-                        </div>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleSocialShare('facebook')}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <div className='h-4 w-4 rounded bg-blue-600'></div>
-                          페이스북
-                        </div>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() => handleSocialShare('kakao')}
-                      >
-                        <div className='flex items-center gap-2'>
-                          <div className='h-4 w-4 rounded bg-yellow-400'></div>
-                          카카오톡
-                        </div>
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-
-                  {/* 게시글 액션 메뉴 */}
-                  {canDeletePost() && (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant='ghost'
-                          size='sm'
-                          className='h-8 w-8 p-0'
-                        >
-                          <MoreVertical className='h-4 w-4' />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align='end'>
-                        <DropdownMenuItem
-                          onClick={() => setShowDeleteDialog(true)}
-                          className='text-red-600 focus:text-red-600'
-                        >
-                          <Trash2 className='mr-2 h-4 w-4' />
-                          삭제
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  )}
-                </div>
-              </div>
-            </CardHeader>
-
-            <CardContent>
-              {/* 포스트 내용 */}
-              <div className='prose mb-6 max-w-none'>
-                <p className='whitespace-pre-wrap text-gray-700'>
-                  {post.content || '내용 없음'}
-                </p>
-              </div>
-
-              {/* 이미지 */}
-              {post.images && post.images.length > 0 && (
-                <div className='mb-6 grid grid-cols-1 gap-4 md:grid-cols-2'>
-                  {Array.isArray(post.images) &&
-                    post.images.map((image, index) => (
-                      <img
-                        key={index}
-                        src={image}
-                        alt={`이미지 ${index + 1}`}
-                        className='h-64 w-full rounded-lg object-cover'
-                      />
-                    ))}
-                </div>
-              )}
-
-              {/* 액션 버튼 */}
-              <div className='flex items-center gap-4 border-t border-gray-200 py-4'>
-                <Button
-                  variant='ghost'
-                  onClick={handleLike}
-                  disabled={isLiking}
-                  className={`flex items-center gap-2 ${isLiked ? 'text-red-500' : ''}`}
-                >
-                  <Heart
-                    className={`h-5 w-5 ${isLiked ? 'fill-current' : ''}`}
-                  />
-                  좋아요 {typeof post.likes === 'number' ? post.likes : 0}
-                </Button>
-                <Button
-                  variant='ghost'
-                  onClick={handleDislike}
-                  disabled={isDisliking}
-                  className={`flex items-center gap-2 ${isDisliked ? 'text-blue-500' : ''}`}
-                >
-                  <svg
-                    className={`h-5 w-5 ${isDisliked ? 'fill-current' : ''}`}
-                    fill='none'
-                    stroke='currentColor'
-                    viewBox='0 0 24 24'
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      strokeWidth={2}
-                      d='M7 13l3 3 7-7'
-                    />
-                  </svg>
-                  싫어요 {typeof post.dislikes === 'number' ? post.dislikes : 0}
-                </Button>
-                <div className='flex items-center gap-2 text-gray-500'>
-                  <MessageCircle className='h-5 w-5' />
-                  댓글 {typeof post.replies === 'number' ? post.replies : 0}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* 댓글 섹션 */}
-        <Card>
-          <CardHeader>
-            <CardTitle className='text-lg'>
-              댓글 ({typeof post.replies === 'number' ? post.replies : 0})
-            </CardTitle>
-          </CardHeader>
-
+        <Card className='mb-6'>
+          <PostHeader
+            post={post}
+            copiedLink={copiedLink}
+            onCopyLink={handleCopyLink}
+            onShare={handleSocialShare}
+            canDelete={canDeletePost}
+            onRequestDelete={() => setShowDeleteDialog(true)}
+          />
           <CardContent>
-            {/* 댓글 작성 폼 */}
-            {user && (
-              <form onSubmit={handleCommentSubmit} className='mb-6'>
-                <div className='flex gap-3'>
-                  <Avatar className='h-10 w-10'>
-                    <AvatarImage src={user.avatar} />
-                    <AvatarFallback>{getFirstChar(user.name)}</AvatarFallback>
-                  </Avatar>
-                  <div className='flex-1'>
-                    <Input
-                      value={comment}
-                      onChange={e => setComment(e.target.value)}
-                      placeholder='댓글을 입력하세요...'
-                      maxLength={1000}
-                      disabled={isSubmittingComment}
-                    />
-                    <div className='mt-1 text-right text-sm text-gray-500'>
-                      {comment.length}/1000
-                    </div>
-                  </div>
-                  <Button
-                    type='submit'
-                    disabled={!comment.trim() || isSubmittingComment}
-                    size='sm'
-                  >
-                    {isSubmittingComment ? '작성 중...' : '댓글 작성'}
-                  </Button>
-                </div>
-              </form>
+            <div className='prose mb-6 max-w-none'>
+              <p className='whitespace-pre-wrap text-gray-700'>
+                {post.content || '내용 없음'}
+              </p>
+            </div>
+
+            {post.images.length > 0 && (
+              <div className='mb-6 grid grid-cols-1 gap-4 md:grid-cols-2'>
+                {post.images.map((image, index) => (
+                  <img
+                    key={index}
+                    src={image}
+                    alt={`이미지 ${index + 1}`}
+                    className='h-64 w-full rounded-lg object-cover'
+                  />
+                ))}
+              </div>
             )}
 
-            {/* 댓글 목록 */}
-            <div className='space-y-4'>
-              {(() => {
-                const comments = Array.isArray(post.comments)
-                  ? post.comments
-                  : [];
+            <ReactionBar
+              likes={post.likes}
+              dislikes={post.dislikes}
+              commentsCount={commentsCount}
+              isLiked={isLiked}
+              isDisliked={isDisliked}
+              isLiking={isLiking}
+              isDisliking={isDisliking}
+              onLike={handleLike}
+              onDislike={handleDislike}
+            />
+          </CardContent>
+        </Card>
 
-                if (comments.length === 0) {
-                  return (
-                    <p className='py-8 text-center text-gray-500'>
-                      아직 댓글이 없습니다. 첫 번째 댓글을 작성해보세요!
-                    </p>
-                  );
-                }
+        <Card>
+          <CardHeader>
+            <CardTitle className='text-lg'>댓글 ({commentsCount})</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {user && (
+              <CommentComposer
+                user={{ name: user.name, avatar: user.avatar }}
+                value={comment}
+                onChange={handleCommentChange}
+                onSubmit={handleCommentSubmit}
+                isSubmitting={isSubmittingComment}
+              />
+            )}
 
-                return comments.map(comment => {
-                  // comment가 유효한 객체인지 확인
-                  if (!comment || typeof comment !== 'object' || !comment.id) {
-                    return null;
-                  }
-
-                  return (
-                    <div
-                      key={comment.id}
-                      className='flex gap-3 rounded-lg bg-gray-50 p-4'
-                    >
-                      <Avatar className='h-10 w-10'>
-                        <AvatarFallback>
-                          {getFirstChar(comment.author || 'U')}
-                        </AvatarFallback>
-                      </Avatar>
-                      <div className='flex-1'>
-                        <div className='mb-2 flex items-center justify-between'>
-                          <div className='flex items-center gap-2'>
-                            <span className='text-sm font-medium'>
-                              {getUsername(comment.author || 'Unknown')}
-                            </span>
-                            <span className='text-xs text-gray-500'>
-                              {comment.timeAgo || '방금 전'}
-                            </span>
-                          </div>
-                          {canDeleteComment(comment.authorId || '') && (
-                            <Button
-                              variant='ghost'
-                              size='sm'
-                              onClick={() => handleCommentDelete(comment.id)}
-                              className='h-auto p-1 text-red-500 hover:text-red-700'
-                            >
-                              <Trash2 className='h-4 w-4' />
-                            </Button>
-                          )}
-                        </div>
-                        <p className='text-gray-700'>{comment.content || ''}</p>
-
-                        {/* 대댓글 작성 버튼 */}
-                        {user && (
-                          <div className='mt-3'>
-                            <Button
-                              variant='ghost'
-                              size='sm'
-                              onClick={() => setReplyingTo(comment.id)}
-                              className='text-sm text-blue-600 hover:text-blue-700'
-                            >
-                              답글 달기
-                            </Button>
-                          </div>
-                        )}
-
-                        {/* 대댓글 작성 폼 */}
-                        {replyingTo === comment.id && (
-                          <form
-                            onSubmit={e => handleReplySubmit(e, comment.id)}
-                            className='mt-3'
-                          >
-                            <div className='flex gap-2'>
-                              <Input
-                                value={replyContent}
-                                onChange={e => setReplyContent(e.target.value)}
-                                placeholder={`${getUsername(comment.author || 'Unknown')}님에게 답글 달기...`}
-                                maxLength={500}
-                                disabled={isSubmittingReply}
-                                className='flex-1'
-                              />
-                              <Button
-                                type='submit'
-                                disabled={
-                                  !replyContent.trim() || isSubmittingReply
-                                }
-                                size='sm'
-                              >
-                                {isSubmittingReply ? '작성 중...' : '답글'}
-                              </Button>
-                              <Button
-                                type='button'
-                                variant='outline'
-                                size='sm'
-                                onClick={cancelReply}
-                              >
-                                취소
-                              </Button>
-                            </div>
-                            <div className='mt-1 text-right text-xs text-gray-500'>
-                              {replyContent.length}/500
-                            </div>
-                          </form>
-                        )}
-
-                        {renderReplies(comment.replies || [])}
-                      </div>
-                    </div>
-                  );
-                });
-              })()}
-            </div>
+            <CommentThread
+              comments={post.comments}
+              replyingTo={replyingTo}
+              replyContent={replyContent}
+              allowReply={Boolean(user)}
+              onReplyChange={handleReplyChange}
+              onReplySubmit={handleReplySubmit}
+              onDeleteComment={handleCommentDelete}
+              onStartReply={handleStartReply}
+              onCancelReply={cancelReply}
+              canDeleteComment={canDeleteComment}
+              isSubmittingReply={isSubmittingReply}
+            />
           </CardContent>
         </Card>
       </div>
 
-      {/* 삭제 확인 모달 */}
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>게시글 삭제</AlertDialogTitle>
-            <AlertDialogDescription>
-              이 게시글을 정말 삭제하시겠습니까? 삭제된 게시글은 복구할 수
-              없습니다.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={deletePostMutation.isPending}>
-              취소
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleDeletePost}
-              disabled={deletePostMutation.isPending}
-              className='bg-red-600 hover:bg-red-700'
-            >
-              {deletePostMutation.isPending ? '삭제 중...' : '삭제'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeletePostDialog
+        open={showDeleteDialog}
+        onOpenChange={setShowDeleteDialog}
+        onConfirm={handleDeletePost}
+        isDeleting={isDeletingPost}
+      />
     </div>
   );
 };

--- a/src/features/community/components/CommentComposer.tsx
+++ b/src/features/community/components/CommentComposer.tsx
@@ -1,0 +1,62 @@
+import { FC, FormEvent, ChangeEvent } from 'react';
+
+import { Button } from '@/shared/ui/Button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Input } from '@/components/ui/input';
+
+import { getFirstChar } from '@/utils/typeGuards';
+
+interface CommentComposerProps {
+  user: {
+    name: string;
+    avatar?: string;
+  };
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  isSubmitting: boolean;
+  maxLength?: number;
+}
+
+export const CommentComposer: FC<CommentComposerProps> = ({
+  user,
+  value,
+  onChange,
+  onSubmit,
+  isSubmitting,
+  maxLength = 1000,
+}) => {
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.target.value);
+  };
+
+  return (
+    <form onSubmit={onSubmit} className='mb-6'>
+      <div className='flex gap-3'>
+        <Avatar className='h-10 w-10'>
+          <AvatarImage src={user.avatar} />
+          <AvatarFallback>{getFirstChar(user.name)}</AvatarFallback>
+        </Avatar>
+        <div className='flex-1'>
+          <Input
+            value={value}
+            onChange={handleChange}
+            placeholder='댓글을 입력하세요...'
+            maxLength={maxLength}
+            disabled={isSubmitting}
+          />
+          <div className='mt-1 text-right text-sm text-gray-500'>
+            {value.length}/{maxLength}
+          </div>
+        </div>
+        <Button
+          type='submit'
+          disabled={!value.trim() || isSubmitting}
+          size='sm'
+        >
+          {isSubmitting ? '작성 중...' : '댓글 작성'}
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/src/features/community/components/CommentThread.tsx
+++ b/src/features/community/components/CommentThread.tsx
@@ -1,0 +1,212 @@
+import { ChangeEvent, FC, FormEvent } from 'react';
+import { Trash2 } from 'lucide-react';
+
+import { Button } from '@/shared/ui/Button';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Input } from '@/components/ui/input';
+
+import { getFirstChar, getUsername } from '@/utils/typeGuards';
+import { CommunityCommentNode } from '../hooks/useCommunityPostDetail';
+
+interface CommentThreadProps {
+  comments: CommunityCommentNode[];
+  replyingTo: string | null;
+  replyContent: string;
+  allowReply: boolean;
+  onReplyChange: (value: string) => void;
+  onReplySubmit: (event: FormEvent<HTMLFormElement>, parentId: string) => void;
+  onDeleteComment: (commentId: string) => void;
+  onStartReply: (commentId: string) => void;
+  onCancelReply: () => void;
+  canDeleteComment: (authorId: string) => boolean;
+  isSubmittingReply: boolean;
+}
+
+export const CommentThread: FC<CommentThreadProps> = ({
+  comments,
+  replyingTo,
+  replyContent,
+  allowReply,
+  onReplyChange,
+  onReplySubmit,
+  onDeleteComment,
+  onStartReply,
+  onCancelReply,
+  canDeleteComment,
+  isSubmittingReply,
+}) => {
+  if (!comments.length) {
+    return (
+      <p className='py-8 text-center text-gray-500'>
+        아직 댓글이 없습니다. 첫 번째 댓글을 작성해보세요!
+      </p>
+    );
+  }
+
+  const renderReplies = (replies: CommunityCommentNode[]) => {
+    if (!replies.length) {
+      return null;
+    }
+
+    return (
+      <div className='ml-8 mt-3 space-y-3 border-l-2 border-gray-200 pl-4'>
+        {replies.map(reply => (
+          <CommentItem
+            key={reply.id}
+            comment={reply}
+            replyingTo={replyingTo}
+            replyContent={replyContent}
+            allowReply={allowReply}
+            onReplyChange={onReplyChange}
+            onReplySubmit={onReplySubmit}
+            onDeleteComment={onDeleteComment}
+            onStartReply={onStartReply}
+            onCancelReply={onCancelReply}
+            canDeleteComment={canDeleteComment}
+            isSubmittingReply={isSubmittingReply}
+            renderReplies={renderReplies}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className='space-y-4'>
+      {comments.map(comment => (
+        <CommentItem
+          key={comment.id}
+          comment={comment}
+          replyingTo={replyingTo}
+          replyContent={replyContent}
+          allowReply={allowReply}
+          onReplyChange={onReplyChange}
+          onReplySubmit={onReplySubmit}
+          onDeleteComment={onDeleteComment}
+          onStartReply={onStartReply}
+          onCancelReply={onCancelReply}
+          canDeleteComment={canDeleteComment}
+          isSubmittingReply={isSubmittingReply}
+          renderReplies={renderReplies}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface CommentItemProps {
+  comment: CommunityCommentNode;
+  replyingTo: string | null;
+  replyContent: string;
+  allowReply: boolean;
+  onReplyChange: (value: string) => void;
+  onReplySubmit: (event: FormEvent<HTMLFormElement>, parentId: string) => void;
+  onDeleteComment: (commentId: string) => void;
+  onStartReply: (commentId: string) => void;
+  onCancelReply: () => void;
+  canDeleteComment: (authorId: string) => boolean;
+  isSubmittingReply: boolean;
+  renderReplies: (replies: CommunityCommentNode[]) => JSX.Element | null;
+}
+
+const CommentItem: FC<CommentItemProps> = ({
+  comment,
+  replyingTo,
+  replyContent,
+  allowReply,
+  onReplyChange,
+  onReplySubmit,
+  onDeleteComment,
+  onStartReply,
+  onCancelReply,
+  canDeleteComment,
+  isSubmittingReply,
+  renderReplies,
+}) => {
+  const handleReplySubmit = (event: FormEvent<HTMLFormElement>) => {
+    onReplySubmit(event, comment.id);
+  };
+
+  const handleReplyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onReplyChange(event.target.value);
+  };
+
+  return (
+    <div className='flex gap-3 rounded-lg bg-gray-50 p-4'>
+      <Avatar className='h-10 w-10'>
+        <AvatarFallback>{getFirstChar(comment.author || 'U')}</AvatarFallback>
+      </Avatar>
+      <div className='flex-1'>
+        <div className='mb-2 flex items-center justify-between'>
+          <div className='flex items-center gap-2'>
+            <span className='text-sm font-medium'>
+              {getUsername(comment.author || 'Unknown')}
+            </span>
+            <span className='text-xs text-gray-500'>
+              {comment.timeAgo || '방금 전'}
+            </span>
+          </div>
+          {canDeleteComment(comment.authorId || '') && (
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => onDeleteComment(comment.id)}
+              className='h-auto p-1 text-red-500 hover:text-red-700'
+            >
+              <Trash2 className='h-4 w-4' />
+            </Button>
+          )}
+        </div>
+        <p className='text-gray-700'>{comment.content || ''}</p>
+
+        {allowReply && (
+          <div className='mt-3'>
+            <Button
+              variant='ghost'
+              size='sm'
+              onClick={() => onStartReply(comment.id)}
+              className='text-sm text-blue-600 hover:text-blue-700'
+            >
+              답글 달기
+            </Button>
+          </div>
+        )}
+
+        {replyingTo === comment.id && (
+          <form onSubmit={handleReplySubmit} className='mt-3'>
+            <div className='flex gap-2'>
+              <Input
+                value={replyContent}
+                onChange={handleReplyChange}
+                placeholder={`${getUsername(comment.author || 'Unknown')}님에게 답글 달기...`}
+                maxLength={500}
+                disabled={isSubmittingReply}
+                className='flex-1'
+              />
+              <Button
+                type='submit'
+                disabled={!replyContent.trim() || isSubmittingReply}
+                size='sm'
+              >
+                {isSubmittingReply ? '작성 중...' : '답글'}
+              </Button>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                onClick={onCancelReply}
+              >
+                취소
+              </Button>
+            </div>
+            <div className='mt-1 text-right text-xs text-gray-500'>
+              {replyContent.length}/500
+            </div>
+          </form>
+        )}
+
+        {renderReplies(comment.replies)}
+      </div>
+    </div>
+  );
+};

--- a/src/features/community/components/DeletePostDialog.tsx
+++ b/src/features/community/components/DeletePostDialog.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface DeletePostDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isDeleting: boolean;
+}
+
+export const DeletePostDialog: FC<DeletePostDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  isDeleting,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>게시글 삭제</AlertDialogTitle>
+          <AlertDialogDescription>
+            이 게시글을 정말 삭제하시겠습니까? 삭제된 게시글은 복구할 수 없습니다.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>취소</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className='bg-red-600 hover:bg-red-700'
+          >
+            {isDeleting ? '삭제 중...' : '삭제'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/features/community/components/PostHeader.tsx
+++ b/src/features/community/components/PostHeader.tsx
@@ -1,0 +1,124 @@
+import { FC } from 'react';
+import { Eye, MoreVertical, Share2, Trash2, Copy } from 'lucide-react';
+
+import { Button } from '@/shared/ui/Button';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { CardHeader, CardTitle } from '@/components/ui/card';
+
+import { getUsername } from '@/utils/typeGuards';
+import { CommunityPostDetailData } from '../hooks/useCommunityPostDetail';
+
+interface PostHeaderProps {
+  post: CommunityPostDetailData;
+  copiedLink: boolean;
+  onCopyLink: () => void;
+  onShare: (platform: 'twitter' | 'facebook' | 'kakao') => void;
+  canDelete: boolean;
+  onRequestDelete: () => void;
+}
+
+export const PostHeader: FC<PostHeaderProps> = ({
+  post,
+  copiedLink,
+  onCopyLink,
+  onShare,
+  canDelete,
+  onRequestDelete,
+}) => {
+  return (
+    <CardHeader>
+      <div className='flex items-start justify-between gap-4'>
+        <div className='flex-1'>
+          <div className='mb-3 flex items-center gap-2'>
+            {post.category && <Badge variant='secondary'>{post.category}</Badge>}
+            {post.isHot && <Badge variant='destructive'>HOT</Badge>}
+          </div>
+          <CardTitle className='mb-2 text-2xl'>{post.title || '제목 없음'}</CardTitle>
+          <div className='flex flex-wrap items-center gap-4 text-sm text-gray-500'>
+            <span>작성자: {getUsername(post.author)}</span>
+            <span>{post.timeAgo}</span>
+            <span className='flex items-center gap-1'>
+              <Eye className='h-4 w-4' />
+              {post.viewCount}
+            </span>
+          </div>
+        </div>
+
+        <div className='flex items-center gap-2'>
+          <Button
+            variant='ghost'
+            size='sm'
+            onClick={onCopyLink}
+            className='h-8 px-3'
+          >
+            {copiedLink ? (
+              <div className='flex items-center gap-1 text-green-600'>
+                <div className='h-2 w-2 rounded-full bg-green-600' />
+                복사됨
+              </div>
+            ) : (
+              <div className='flex items-center gap-1'>
+                <Copy className='h-4 w-4' />
+                링크 복사
+              </div>
+            )}
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant='ghost' size='sm' className='h-8 px-3'>
+                <Share2 className='mr-1 h-4 w-4' />
+                공유
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align='end'>
+              <DropdownMenuItem onClick={() => onShare('twitter')}>
+                <div className='flex items-center gap-2'>
+                  <div className='h-4 w-4 rounded bg-blue-500' />
+                  트위터
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onShare('facebook')}>
+                <div className='flex items-center gap-2'>
+                  <div className='h-4 w-4 rounded bg-blue-600' />
+                  페이스북
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onShare('kakao')}>
+                <div className='flex items-center gap-2'>
+                  <div className='h-4 w-4 rounded bg-yellow-400' />
+                  카카오톡
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {canDelete && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant='ghost' size='sm' className='h-8 w-8 p-0'>
+                  <MoreVertical className='h-4 w-4' />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align='end'>
+                <DropdownMenuItem
+                  onClick={onRequestDelete}
+                  className='text-red-600 focus:text-red-600'
+                >
+                  <Trash2 className='mr-2 h-4 w-4' />
+                  삭제
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </div>
+    </CardHeader>
+  );
+};

--- a/src/features/community/components/ReactionBar.tsx
+++ b/src/features/community/components/ReactionBar.tsx
@@ -1,0 +1,67 @@
+import { FC } from 'react';
+import { Heart, MessageCircle } from 'lucide-react';
+
+import { Button } from '@/shared/ui/Button';
+
+interface ReactionBarProps {
+  likes: number;
+  dislikes: number;
+  commentsCount: number;
+  isLiked: boolean;
+  isDisliked: boolean;
+  isLiking: boolean;
+  isDisliking: boolean;
+  onLike: () => void;
+  onDislike: () => void;
+}
+
+export const ReactionBar: FC<ReactionBarProps> = ({
+  likes,
+  dislikes,
+  commentsCount,
+  isLiked,
+  isDisliked,
+  isLiking,
+  isDisliking,
+  onLike,
+  onDislike,
+}) => {
+  return (
+    <div className='flex items-center gap-4 border-t border-gray-200 py-4'>
+      <Button
+        variant='ghost'
+        onClick={onLike}
+        disabled={isLiking}
+        className={`flex items-center gap-2 ${isLiked ? 'text-red-500' : ''}`}
+      >
+        <Heart className={`h-5 w-5 ${isLiked ? 'fill-current' : ''}`} />
+        좋아요 {likes}
+      </Button>
+      <Button
+        variant='ghost'
+        onClick={onDislike}
+        disabled={isDisliking}
+        className={`flex items-center gap-2 ${isDisliked ? 'text-blue-500' : ''}`}
+      >
+        <svg
+          className={`h-5 w-5 ${isDisliked ? 'fill-current' : ''}`}
+          fill='none'
+          stroke='currentColor'
+          viewBox='0 0 24 24'
+        >
+          <path
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            strokeWidth={2}
+            d='M7 13l3 3 7-7'
+          />
+        </svg>
+        싫어요 {dislikes}
+      </Button>
+      <div className='flex items-center gap-2 text-gray-500'>
+        <MessageCircle className='h-5 w-5' />
+        댓글 {commentsCount}
+      </div>
+    </div>
+  );
+};

--- a/src/features/community/hooks/useCommunityPostDetail.ts
+++ b/src/features/community/hooks/useCommunityPostDetail.ts
@@ -1,0 +1,536 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+import { useAuth } from '@/contexts/AuthContext';
+import { useAuthRedirect } from '@/hooks/useAuthRedirect';
+import { useCreateComment, useCreateReply, useDeleteComment } from '@/lib/api/useCommunityComments';
+import { usePostReaction } from '@/lib/api/useCommunityReactions';
+import { communityPostAPI } from '@/services/api/community';
+import { useDeleteCommunityPost } from '@/features/community/hooks/useCommunityPosts';
+
+export interface CommunityCommentNode {
+  id: string;
+  author: string;
+  authorId: string;
+  content: string;
+  timeAgo: string;
+  createdAt: Date;
+  replies: CommunityCommentNode[];
+  parentId?: string;
+}
+
+export interface CommunityPostDetailData {
+  id: string;
+  title: string;
+  category: string;
+  author: string;
+  authorId: string;
+  content: string;
+  images: string[];
+  timeAgo: string;
+  replies: number;
+  likes: number;
+  dislikes: number;
+  isLiked: boolean;
+  isDisliked: boolean;
+  isHot: boolean;
+  viewCount: number;
+  views: number;
+  createdAt: Date;
+  updatedAt: Date;
+  comments: CommunityCommentNode[];
+}
+
+interface UseCommunityPostDetailOptions {
+  onBack?: () => void;
+}
+
+const isValidDate = (value: unknown): value is Date => {
+  return value instanceof Date && !isNaN(value.getTime());
+};
+
+const safeDate = (value: unknown): Date => {
+  if (value instanceof Date && isValidDate(value)) {
+    return value;
+  }
+
+  const parsed = value ? new Date(value as string) : new Date();
+  return isValidDate(parsed) ? parsed : new Date();
+};
+
+const toStringSafe = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  return String(value);
+};
+
+const transformComments = (comments: unknown[]): CommunityCommentNode[] => {
+  if (!Array.isArray(comments)) return [];
+
+  return comments
+    .filter(comment => comment && typeof comment === 'object')
+    .map(comment => {
+      const commentRecord = comment as Record<string, unknown>;
+      const createdAt = safeDate(commentRecord.createdAt);
+
+      const replies = Array.isArray(commentRecord.replies)
+        ? transformComments(commentRecord.replies)
+        : [];
+
+      const authorField = commentRecord.author;
+      const authorName =
+        typeof authorField === 'string'
+          ? authorField
+          : typeof authorField === 'object' && authorField
+          ? (authorField as Record<string, unknown>).name ||
+            (authorField as Record<string, unknown>).username ||
+            toStringSafe((authorField as Record<string, unknown>).id)
+          : toStringSafe(commentRecord.authorName);
+
+      const authorId =
+        toStringSafe(commentRecord.authorId) ||
+        (typeof authorField === 'string'
+          ? authorField
+          : toStringSafe((authorField as Record<string, unknown>).id));
+
+      return {
+        id: toStringSafe(commentRecord.id || commentRecord._id),
+        author: authorName || 'Unknown',
+        authorId,
+        content: toStringSafe(commentRecord.content),
+        timeAgo:
+          toStringSafe(commentRecord.timeAgo) ||
+          formatDistanceToNow(createdAt, { addSuffix: true, locale: ko }),
+        createdAt,
+        replies,
+        parentId: commentRecord.parentId
+          ? toStringSafe(commentRecord.parentId)
+          : undefined,
+      };
+    });
+};
+
+const extractPostDetail = (
+  data: Record<string, unknown>,
+  postId: string,
+): CommunityPostDetailData => {
+  const createdAt = safeDate(data.createdAt);
+  const updatedAt = safeDate(data.updatedAt);
+
+  const authorField = data.author;
+  const authorName =
+    typeof authorField === 'string'
+      ? authorField
+      : typeof authorField === 'object' && authorField
+      ? ((authorField as Record<string, unknown>).name as string) || 'Unknown'
+      : 'Unknown';
+
+  const authorId =
+    typeof authorField === 'string'
+      ? authorField
+      : toStringSafe((authorField as Record<string, unknown>).id || authorField);
+
+  const likesRaw = data.likes;
+  const dislikesRaw = data.dislikes;
+
+  const likes = Array.isArray(likesRaw)
+    ? likesRaw.length
+    : typeof likesRaw === 'number'
+    ? likesRaw
+    : 0;
+
+  const dislikes = Array.isArray(dislikesRaw)
+    ? dislikesRaw.length
+    : typeof dislikesRaw === 'number'
+    ? dislikesRaw
+    : 0;
+
+  const replies = Array.isArray(data.comments)
+    ? (data.comments as unknown[]).length
+    : (data.replies as number) || 0;
+
+  return {
+    id: toStringSafe(data.id || data._id) || postId,
+    title: toStringSafe(data.title),
+    category: toStringSafe(data.category),
+    author: authorName,
+    authorId,
+    content: toStringSafe(data.content),
+    images: Array.isArray(data.images)
+      ? (data.images as string[])
+      : [],
+    timeAgo: formatDistanceToNow(createdAt, { addSuffix: true, locale: ko }),
+    replies,
+    likes,
+    dislikes,
+    isLiked: Boolean(data.isLiked),
+    isDisliked: Boolean(data.isDisliked),
+    isHot: likes > 20,
+    viewCount:
+      (typeof data.viewCount === 'number' && data.viewCount) ||
+      (typeof data.views === 'number' && data.views) ||
+      0,
+    views:
+      (typeof data.views === 'number' && data.views) ||
+      (typeof data.viewCount === 'number' && data.viewCount) ||
+      0,
+    createdAt,
+    updatedAt,
+    comments: Array.isArray(data.comments)
+      ? transformComments(data.comments as unknown[])
+      : [],
+  };
+};
+
+export const useCommunityPostDetail = (
+  postId: string,
+  options: UseCommunityPostDetailOptions = {},
+) => {
+  const { user } = useAuth();
+  const { requireAuth } = useAuthRedirect();
+  const deletePostMutation = useDeleteCommunityPost();
+  const postReactionMutation = usePostReaction();
+  const createCommentMutation = useCreateComment();
+  const deleteCommentMutation = useDeleteComment();
+  const createReplyMutation = useCreateReply();
+
+  const [post, setPost] = useState<CommunityPostDetailData | null>(null);
+  const [comment, setComment] = useState('');
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyContent, setReplyContent] = useState('');
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  const postUrl = useMemo(() => {
+    if (typeof window === 'undefined') return '';
+    return `${window.location.origin}/community/post/${postId}`;
+  }, [postId]);
+
+  const fetchPostDetail = useCallback(
+    async (withLoading: boolean = true) => {
+      if (!postId || postId === 'undefined') {
+        setError('유효하지 않은 게시글 ID입니다.');
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        if (withLoading) {
+          setIsLoading(true);
+        }
+        const response = await communityPostAPI.getPost(postId);
+        const postData =
+          response && typeof response === 'object' && 'data' in response
+            ? (response as { data: unknown }).data
+            : response;
+
+        if (postData && typeof postData === 'object') {
+          const formattedPost = extractPostDetail(
+            postData as Record<string, unknown>,
+            postId,
+          );
+          setPost(formattedPost);
+          setError('');
+        } else {
+          setError('포스트를 불러올 수 없습니다.');
+          setPost(null);
+        }
+      } catch (err) {
+        console.error('포스트 상세 조회 오류:', err);
+        let errorMessage = '포스트 조회 중 오류가 발생했습니다.';
+        if (err instanceof Error) {
+          if (err.message.includes('서버 리소스가 부족합니다')) {
+            errorMessage =
+              '서버가 일시적으로 과부하 상태입니다. 잠시 후 다시 시도해주세요.';
+          } else if (err.message.includes('요청 시간이 초과되었습니다')) {
+            errorMessage =
+              '요청 시간이 초과되었습니다. 네트워크 연결을 확인해주세요.';
+          } else if (err.message.includes('Failed to fetch')) {
+            errorMessage =
+              '네트워크 연결에 문제가 있습니다. 인터넷 연결을 확인해주세요.';
+          }
+        }
+        setPost(null);
+        setError(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [postId],
+  );
+
+  useEffect(() => {
+    fetchPostDetail();
+  }, [fetchPostDetail]);
+
+  const refreshPost = useCallback(() => fetchPostDetail(false), [fetchPostDetail]);
+
+  const handleBack = useCallback(() => {
+    if (options.onBack) {
+      options.onBack();
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.history.back();
+    }
+  }, [options]);
+
+  const handleCopyLink = useCallback(async () => {
+    if (typeof navigator === 'undefined' || !postUrl) return;
+
+    try {
+      await navigator.clipboard.writeText(postUrl);
+      setCopiedLink(true);
+      setTimeout(() => setCopiedLink(false), 2000);
+    } catch (err) {
+      console.error('링크 복사 실패:', err);
+    }
+  }, [postUrl]);
+
+  const handleSocialShare = useCallback(
+    (platform: 'twitter' | 'facebook' | 'kakao') => {
+      if (typeof window === 'undefined' || !postUrl) return;
+      const title = post?.title || '게시글';
+
+      switch (platform) {
+        case 'twitter':
+          window.open(
+            `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+              title,
+            )}&url=${encodeURIComponent(postUrl)}`,
+            '_blank',
+          );
+          break;
+        case 'facebook':
+          window.open(
+            `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(
+              postUrl,
+            )}`,
+            '_blank',
+          );
+          break;
+        case 'kakao':
+          handleCopyLink();
+          break;
+        default:
+          break;
+      }
+    },
+    [handleCopyLink, post?.title, postUrl],
+  );
+
+  const handleLike = useCallback(() => {
+    requireAuth(() => {
+      if (!user || !post) return;
+
+      const action = post.isLiked ? 'unlike' : 'like';
+      postReactionMutation.mutate(
+        { postId, reaction: action },
+        {
+          onSuccess: data => {
+            setPost(prev =>
+              prev
+                ? {
+                    ...prev,
+                    likes: data.likes,
+                    dislikes: data.dislikes,
+                    isLiked: data.isLiked,
+                    isDisliked: data.isDisliked,
+                    isHot: data.likes > 20,
+                  }
+                : prev,
+            );
+          },
+          onError: err => {
+            console.error('좋아요 처리 오류:', err);
+          },
+        },
+      );
+    });
+  }, [post, postId, postReactionMutation, requireAuth, user]);
+
+  const handleDislike = useCallback(() => {
+    requireAuth(() => {
+      if (!user || !post) return;
+
+      const action = post.isDisliked ? 'undislike' : 'dislike';
+      postReactionMutation.mutate(
+        { postId, reaction: action },
+        {
+          onSuccess: data => {
+            setPost(prev =>
+              prev
+                ? {
+                    ...prev,
+                    likes: data.likes,
+                    dislikes: data.dislikes,
+                    isLiked: data.isLiked,
+                    isDisliked: data.isDisliked,
+                  }
+                : prev,
+            );
+          },
+          onError: err => {
+            console.error('싫어요 처리 오류:', err);
+          },
+        },
+      );
+    });
+  }, [post, postId, postReactionMutation, requireAuth, user]);
+
+  const handleCommentSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!comment.trim() || !post) return;
+
+      requireAuth(() => {
+        if (!user) return;
+
+        createCommentMutation.mutate(
+          { postId, content: comment.trim() },
+          {
+            onSuccess: () => {
+              setComment('');
+              refreshPost();
+            },
+            onError: err => {
+              console.error('댓글 작성 실패:', err);
+            },
+          },
+        );
+      });
+    },
+    [comment, createCommentMutation, post, postId, refreshPost, requireAuth, user],
+  );
+
+  const handleCommentDelete = useCallback(
+    (commentId: string) => {
+      requireAuth(() => {
+        if (!user || !post) return;
+
+        deleteCommentMutation.mutate(
+          { postId, commentId },
+          {
+            onSuccess: () => {
+              refreshPost();
+            },
+            onError: err => {
+              console.error('댓글 삭제 실패:', err);
+            },
+          },
+        );
+      });
+    },
+    [deleteCommentMutation, post, postId, refreshPost, requireAuth, user],
+  );
+
+  const handleReplySubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>, parentCommentId: string) => {
+      event.preventDefault();
+      if (!replyContent.trim() || !post) return;
+
+      requireAuth(() => {
+        if (!user) return;
+
+        createReplyMutation.mutate(
+          { postId, parentCommentId, content: replyContent.trim() },
+          {
+            onSuccess: () => {
+              setReplyContent('');
+              setReplyingTo(null);
+              refreshPost();
+            },
+            onError: err => {
+              console.error('대댓글 작성 실패:', err);
+            },
+          },
+        );
+      });
+    },
+    [createReplyMutation, post, postId, refreshPost, replyContent, requireAuth, user],
+  );
+
+  const cancelReply = useCallback(() => {
+    setReplyingTo(null);
+    setReplyContent('');
+  }, []);
+
+  const handleDeletePost = useCallback(async () => {
+    if (!user || !post) return;
+
+    try {
+      await deletePostMutation.mutateAsync(postId);
+      if (options.onBack) {
+        options.onBack();
+      }
+    } catch (err) {
+      console.error('게시글 삭제 실패:', err);
+    }
+  }, [deletePostMutation, options, post, postId, user]);
+
+  const canDeleteComment = useCallback(
+    (commentAuthorId: string) => {
+      return Boolean(
+        user && post && (user.id === commentAuthorId || user.id === post.authorId),
+      );
+    },
+    [post, user],
+  );
+
+  const canDeletePost = useMemo(() => {
+    return Boolean(
+      user && post && (user.id === post.authorId || user.role === 'admin'),
+    );
+  }, [post, user]);
+
+  const isLiked = Boolean(post?.isLiked);
+  const isDisliked = Boolean(post?.isDisliked);
+
+  return {
+    post,
+    isLoading,
+    error,
+    state: {
+      comment,
+      replyingTo,
+      replyContent,
+      copiedLink,
+      showDeleteDialog,
+    },
+    status: {
+      isLiked,
+      isDisliked,
+      isLiking: postReactionMutation.isPending,
+      isDisliking: postReactionMutation.isPending,
+      isSubmittingComment: createCommentMutation.isPending,
+      isSubmittingReply: createReplyMutation.isPending,
+      isDeletingPost: deletePostMutation.isPending,
+    },
+    setComment,
+    setReplyingTo,
+    setReplyContent,
+    setShowDeleteDialog,
+    actions: {
+      handleBack,
+      handleCopyLink,
+      handleSocialShare,
+      handleLike,
+      handleDislike,
+      handleCommentSubmit,
+      handleCommentDelete,
+      handleReplySubmit,
+      cancelReply,
+      handleDeletePost,
+    },
+    permissions: {
+      canDeleteComment,
+      canDeletePost,
+    },
+  };
+};
+
+export type UseCommunityPostDetailReturn = ReturnType<typeof useCommunityPostDetail>;


### PR DESCRIPTION
## Summary
- add a dedicated `useCommunityPostDetail` hook that normalizes post data, encapsulates reactions/comments, and exposes navigation and sharing helpers
- split the post detail UI into reusable components for header, reactions, comment composition, threaded replies, and deletion confirmation
- refactor `CommunityPostDetail` to consume the new hook and presentational pieces, simplifying its logic while preserving the existing layout

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d216fb8a948326bfbb64df1d59896a