### PR TITLE
feat: define prisma schema and share enums

### DIFF
--- a/prisma/README.md
+++ b/prisma/README.md
@@ -1,0 +1,34 @@
+# Prisma Data Model Overview
+
+이 문서는 기존 Mongoose 모델을 Prisma 기반 PostgreSQL 스키마로 이전하면서 고려해야 할 뷰 모델 및 서비스 계층 책임을 정리합니다.
+
+## 핵심 개념
+
+- **정규화**: 배열 필드로 표현되던 `Project.tasks`, `FundingProject.rewards`, `CommunityPost.comments` 등을 전용 테이블로 분리했습니다. 각 테이블은 복합 인덱스를 제공하여 검색 성능을 보장합니다.
+- **JSONB 활용**: `Payment.metadata`, `Artist.socialLinks`, `Artwork.metadata` 등 Map/Mixed 타입은 PostgreSQL `Json` 컬럼으로 치환하여 유연한 스키마를 유지했습니다.
+- **Prisma Enum 공유**: `@prisma/client` 에 정의된 enum 을 재사용하여 프런트엔드와 백엔드가 동일한 상수 집합을 참조할 수 있도록 `server/constants/enums.js` 를 갱신했습니다.
+
+## 서비스 계층으로 이동한 계산 로직
+
+| 대상 | 이전 동작 | 현재 설계 |
+| ---- | -------- | -------- |
+| 프로젝트 진행률 | Mongoose pre-save 훅에서 `progress` 갱신 | `Project` 모델에 `progress`, `spent` 필드를 유지하고, 서비스 레이어에서 태스크/마일스톤 상태를 기반으로 배치 업데이트. `ProjectTask`/`ProjectMilestone`에 인덱스가 있어 효율적 계산 가능 |
+| 펀딩 진행 현황 | pre-save 훅에서 `daysLeft`, `progress`, `status` 조정 | `FundingProject`에 동일 필드를 저장하되, 예약된 잡 또는 서비스 함수(`updateFundingProgress`)가 남은 일수/달성률을 계산하여 갱신 |
+| 수익 분배 | Map 필드에서 분배 내역 계산 | `FundingProjectDistribution` 및 `RevenueDistribution` 테이블로 분리. 서비스 계층이 정산 시점에 분배 합계를 계산하고 `RevenueDistribution`의 `processedAt`, `payoutStatus`를 갱신 |
+| 라이브 스트림 상태 | pre-save 훅에서 `status` 전환 | `LiveStream` 레코드에 `scheduledAt`, `startedAt`, `endedAt`, `isLive` 필드를 유지하고, 스트림 제어 서비스가 상태 전환을 책임짐 |
+| 커뮤니티 반응 수 | 가상 필드에서 길이를 계산 | `CommunityPostReaction`, `TrackLike` 테이블을 통해 COUNT 쿼리 및 캐싱 전략 사용 |
+
+## 뷰 모델 제안
+
+- **ProjectProgressView**: `Project` 와 연관된 `ProjectTask`, `ProjectMilestone` 를 조인하여 진행률, 지연 마일스톤 수를 계산하는 서비스 DTO.
+- **FundingDashboardView**: `FundingProject`, `Pledge`, `Payment`, `FundingProjectDistribution` 를 묶어 후원자 수, 평균 후원금, 분배 상태를 요약.
+- **RevenuePayoutView**: `RevenueDistribution` 과 `CreatorPayout` 데이터를 조합하여 관리자 화면에 필요한 상태/재시도 가능 여부를 계산.
+- **EngagementSnapshot**: `Track`, `TrackLike`, `Artwork` 지표를 합산하여 아티스트 대시보드용 KPI 생성.
+
+이러한 뷰 모델은 Prisma의 `include`/`select` 기능과 서비스 계층의 집계 로직을 결합하여 구현합니다.
+
+## 마이그레이션 팁
+
+1. Prisma Client 생성 후 `@prisma/client` 를 서버와 프런트 공통 유틸에서 재사용합니다.
+2. 배열이 테이블로 분리되면서 생성/갱신 시 트랜잭션(`prisma.$transaction`)을 활용하여 일관성을 유지합니다.
+3. pre-save 훅 대체 로직은 스케줄러(예: BullMQ)나 서비스 메서드에서 실행하며, 관련 필드에 대한 인덱스를 통해 퍼포먼스를 확보합니다.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,1072 @@
+// Prisma schema for Collaboreum Platform relational data model
+// Generated to migrate from Mongoose models to PostgreSQL
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  ARTIST @map("artist")
+  ADMIN  @map("admin")
+  FAN    @map("fan")
+}
+
+enum ArtistCategory {
+  MUSIC       @map("음악")
+  ART         @map("미술")
+  VIDEO       @map("영상")
+  LITERATURE  @map("문학")
+  CRAFT       @map("공예")
+  DESIGN      @map("디자인")
+  OTHER       @map("기타")
+}
+
+enum ArtistGenre {
+  POP          @map("팝")
+  ROCK         @map("록")
+  RNB          @map("R&B")
+  JAZZ         @map("재즈")
+  CLASSICAL    @map("클래식")
+  HIPHOP       @map("힙합")
+  ELECTRONIC   @map("일렉트로닉")
+  INDIE        @map("인디")
+  ALTERNATIVE  @map("얼터너티브")
+  COUNTRY      @map("컨트리")
+  REGGAE       @map("레게")
+  BLUES        @map("블루스")
+  SOUL         @map("소울")
+  PUNK         @map("펑크")
+  METAL        @map("메탈")
+  OTHER        @map("기타")
+}
+
+enum ProjectCategory {
+  MUSIC        @map("음악")
+  VIDEO        @map("비디오")
+  PERFORMANCE  @map("공연")
+  BOOK         @map("도서")
+  GAME         @map("게임")
+  OTHER        @map("기타")
+}
+
+enum ProjectStatus {
+  PLANNING    @map("계획중")
+  IN_PROGRESS @map("진행중")
+  COMPLETED   @map("완료")
+  PENDING     @map("보류")
+  CANCELLED   @map("취소")
+}
+
+enum ProjectApprovalStatus {
+  PENDING   @map("pending")
+  APPROVED  @map("approved")
+  REJECTED  @map("rejected")
+}
+
+enum ProjectTaskStatus {
+  WAITING     @map("대기")
+  IN_PROGRESS @map("진행중")
+  COMPLETED   @map("완료")
+  PENDING     @map("보류")
+}
+
+enum ProjectMilestoneStatus {
+  SCHEDULED   @map("예정")
+  IN_PROGRESS @map("진행중")
+  COMPLETED   @map("완료")
+  DELAYED     @map("지연")
+}
+
+enum PriorityLevel {
+  LOW     @map("낮음")
+  MEDIUM  @map("보통")
+  HIGH    @map("높음")
+  URGENT  @map("긴급")
+}
+
+enum EventCategory {
+  FESTIVAL     @map("축제")
+  PERFORMANCE  @map("공연")
+  COMPETITION  @map("경연")
+  WORKSHOP     @map("워크샵")
+  SEMINAR      @map("세미나")
+  OTHER        @map("기타")
+}
+
+enum EventStatus {
+  SCHEDULED   @map("예정")
+  IN_PROGRESS @map("진행중")
+  COMPLETED   @map("완료")
+  CANCELLED   @map("취소")
+}
+
+enum EventTicketType {
+  REGULAR    @map("일반")
+  VIP        @map("VIP")
+  EARLY_BIRD @map("얼리버드")
+  STUDENT    @map("학생")
+}
+
+enum LiveStreamCategory {
+  MUSIC      @map("음악")
+  PERFORMANCE @map("공연")
+  TALK       @map("토크")
+  WORKSHOP   @map("워크샵")
+  OTHER      @map("기타")
+}
+
+enum LiveStreamStatus {
+  SCHEDULED @map("예정")
+  LIVE      @map("라이브")
+  ENDED     @map("종료")
+  CANCELLED @map("취소")
+}
+
+enum FundingProjectStatus {
+  PREPARING  @map("준비중")
+  IN_PROGRESS @map("진행중")
+  SUCCESS    @map("성공")
+  FAILED     @map("실패")
+  CANCELLED  @map("취소")
+  EXECUTING  @map("집행중")
+  COMPLETED  @map("완료")
+}
+
+enum FundingProjectType {
+  REGULAR              @map("일반")
+  EXECUTION_IN_PROGRESS @map("집행진행")
+  EXPENSE_PUBLIC       @map("비용공개")
+  REVENUE_DISTRIBUTION @map("수익분배")
+}
+
+enum FundingExecutionStatus {
+  PLANNED     @map("계획")
+  IN_PROGRESS @map("진행중")
+  COMPLETED   @map("완료")
+  DELAYED     @map("지연")
+}
+
+enum FundingExpenseCategory {
+  LABOR      @map("인건비")
+  MATERIAL   @map("재료비")
+  EQUIPMENT  @map("장비비")
+  MARKETING  @map("마케팅비")
+  OTHER      @map("기타")
+}
+
+enum FundingDistributionStatus {
+  WAITING      @map("대기")
+  DISTRIBUTED  @map("분배완료")
+  PAID         @map("지급완료")
+}
+
+enum FundingUpdateType {
+  GENERAL            @map("일반")
+  EXECUTION_PROGRESS @map("집행진행")
+  EXPENSE_PUBLIC     @map("비용공개")
+  REVENUE_SHARE      @map("수익분배")
+}
+
+enum DistributionStatus {
+  PENDING    @map("pending")
+  PROCESSING @map("processing")
+  COMPLETED  @map("completed")
+  FAILED     @map("failed")
+}
+
+enum ExpenseVerificationStatus {
+  PENDING    @map("pending")
+  VERIFIED   @map("verified")
+  REJECTED   @map("rejected")
+}
+
+enum TrackGenre {
+  INDIE_POP   @map("인디팝")
+  ROCK        @map("록")
+  ACOUSTIC    @map("어쿠스틱")
+  JAZZ        @map("재즈")
+  CLASSICAL   @map("클래식")
+  ELECTRONIC  @map("일렉트로닉")
+  HIPHOP      @map("힙합")
+  RNB         @map("R&B")
+  OTHER       @map("기타")
+}
+
+enum MusicMood {
+  EXCITING   @map("신나는")
+  EMOTIONAL  @map("감성적인")
+  CALM       @map("잔잔한")
+  INTENSE    @map("강렬한")
+  MELANCHOLY @map("우울한")
+  HOPEFUL    @map("희망적인")
+  ROMANTIC   @map("로맨틱한")
+  MYSTERIOUS @map("신비로운")
+}
+
+enum MusicKey {
+  C
+  C_SHARP  @map("C#")
+  D
+  D_SHARP  @map("D#")
+  E
+  F
+  F_SHARP  @map("F#")
+  G
+  G_SHARP  @map("G#")
+  A
+  A_SHARP  @map("A#")
+  B
+}
+
+enum LicenseType {
+  ALL_RIGHTS_RESERVED @map("All Rights Reserved")
+  CREATIVE_COMMONS    @map("Creative Commons")
+  PUBLIC_DOMAIN       @map("Public Domain")
+}
+
+enum ArtworkCategory {
+  MUSIC      @map("음악")
+  ART        @map("미술")
+  LITERATURE @map("문학")
+  PERFORMANCE @map("공연")
+}
+
+enum ArtworkType {
+  AUDIO @map("audio")
+  IMAGE @map("image")
+  VIDEO @map("video")
+  TEXT  @map("text")
+}
+
+enum ArtworkStatus {
+  DRAFT     @map("draft")
+  PUBLISHED @map("published")
+  ARCHIVED  @map("archived")
+}
+
+enum NotificationType {
+  FUNDING  @map("funding")
+  EVENT    @map("event")
+  POINT    @map("point")
+  FOLLOW   @map("follow")
+  PROJECT  @map("project")
+  COMMENT  @map("comment")
+  LIKE     @map("like")
+  SYSTEM   @map("system")
+}
+
+enum PaymentMethod {
+  CARD   @map("card")
+  BANK   @map("bank")
+  KAKAO  @map("kakao")
+  NAVER  @map("naver")
+}
+
+enum PaymentProvider {
+  TOSS    @map("toss")
+  IAMPORT @map("iamport")
+}
+
+enum PaymentStatus {
+  PENDING   @map("pending")
+  COMPLETED @map("completed")
+  FAILED    @map("failed")
+  CANCELLED @map("cancelled")
+  REFUNDED  @map("refunded")
+}
+
+enum CommunityPostCategory {
+  FREE      @map("자유")
+  QUESTION  @map("질문")
+  MUSIC     @map("음악")
+  ART       @map("미술")
+  LITERATURE @map("문학")
+  PERFORMANCE @map("공연")
+  PHOTOGRAPHY @map("사진")
+  TECHNOLOGY  @map("기술")
+  OTHER       @map("기타")
+}
+
+enum ReactionType {
+  LIKE
+  DISLIKE
+}
+
+model User {
+  id             String   @id @default(cuid())
+  name           String
+  username       String?  @unique
+  email          String   @unique
+  password       String
+  role           UserRole @default(FAN)
+  avatar         String   @default("/avatars/default.jpg")
+  bio            String?
+  isVerified     Boolean  @default(false)
+  isActive       Boolean  @default(true)
+  lastLogin      DateTime?
+  lastLoginAt    DateTime?
+  agreeTerms     Boolean  @default(false)
+  agreePrivacy   Boolean  @default(false)
+  agreeMarketing Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  artistProfile        Artist?
+  artistRecords        Artist[]
+  projects             Project[]         @relation("ProjectOwner")
+  approvedProjects     Project[]         @relation("ProjectApprover")
+  projectTeams         ProjectTeamMember[]
+  projectNotes         ProjectNote[]
+  projectTasks         ProjectTask[]     @relation("TaskAssignee")
+  fundingProjects      FundingProject[]  @relation("FundingProjectOwner")
+  pledges             Pledge[]
+  fundingDistributions FundingProjectDistribution[]
+  payments             Payment[]         @relation("PaymentBacker")
+  communityPosts       CommunityPost[]
+  communityComments    CommunityPostComment[]
+  communityReplies     CommunityPostReply[]
+  communityReactions   CommunityPostReaction[]
+  trackLikes           TrackLike[]
+  eventsCreated        Event[]
+  eventAttendances     EventAttendee[]
+  liveStreams          LiveStream[]
+  liveStreamAccess     LiveStreamAccess[]
+  notifications        Notification[]
+  artworks             Artwork[]
+  revenueDistributions RevenueDistribution[] @relation("RevenueCreator")
+  revenueManagements   RevenueDistribution[] @relation("RevenueManager")
+  creatorPayouts       CreatorPayout[]
+}
+
+model Artist {
+  id               String          @id @default(cuid())
+  userId           String          @unique
+  user             User            @relation(fields: [userId], references: [id])
+  category         ArtistCategory
+  location         String
+  rating           Float           @default(0)
+  tags             String[]
+  coverImage       String?
+  profileImage     String?
+  followers        Int             @default(0)
+  completedProjects Int            @default(0)
+  activeProjects   Int             @default(0)
+  totalEarned      Decimal         @default(0) @db.Decimal(18, 2)
+  genres           ArtistGenre[]
+  totalStreams     Int             @default(0)
+  monthlyListeners Int             @default(0)
+  socialLinks      Json?
+  isVerified       Boolean         @default(false)
+  verificationDate DateTime?
+  featured         Boolean         @default(false)
+  featuredDate     DateTime?
+  createdAt        DateTime        @default(now())
+  updatedAt        DateTime        @updatedAt
+
+  achievements     ArtistAchievement[]
+  tracks           Track[]
+  events           Event[]
+  projects         Project[]
+  fundingProjects  FundingProject[]
+
+  @@index([category])
+  @@index([location])
+  @@index([rating])
+  @@index([followers])
+  @@index([totalStreams])
+  @@index([featured, featuredDate])
+}
+
+model ArtistAchievement {
+  id          String   @id @default(cuid())
+  artistId    String
+  artist      Artist   @relation(fields: [artistId], references: [id])
+  title       String
+  description String?
+  date        DateTime?
+  image       String?
+  createdAt   DateTime @default(now())
+
+  @@index([artistId, date])
+}
+
+model Project {
+  id             String                @id @default(cuid())
+  title          String
+  description    String
+  artistId       String
+  artist         User                  @relation("ProjectOwner", fields: [artistId], references: [id])
+  artistName     String
+  category       ProjectCategory
+  status         ProjectStatus         @default(PLANNING)
+  progress       Int                   @default(0)
+  startDate      DateTime
+  endDate        DateTime
+  budget         Decimal               @db.Decimal(18, 2)
+  spent          Decimal               @default(0) @db.Decimal(18, 2)
+  image          String?
+  approvalStatus ProjectApprovalStatus @default(PENDING)
+  approvalReason String?
+  approvedAt     DateTime?
+  approvedById   String?
+  approvedBy     User?                 @relation("ProjectApprover", fields: [approvedById], references: [id])
+  isActive       Boolean               @default(true)
+  isPublic       Boolean               @default(true)
+  priority       PriorityLevel         @default(MEDIUM)
+  tags           String[]
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+
+  tasks          ProjectTask[]
+  milestones     ProjectMilestone[]
+  teamMembers    ProjectTeamMember[]
+  notes          ProjectNote[]
+  fundingProjects FundingProject[]
+
+  @@index([status, endDate])
+}
+
+model ProjectTask {
+  id          String            @id @default(cuid())
+  projectId   String
+  project     Project           @relation(fields: [projectId], references: [id])
+  taskNumber  Int
+  title       String
+  description String?
+  status      ProjectTaskStatus @default(WAITING)
+  progress    Int               @default(0)
+  assigneeId  String?
+  assignee    User?             @relation("TaskAssignee", fields: [assigneeId], references: [id])
+  dueDate     DateTime?
+  completedAt DateTime?
+  createdAt   DateTime          @default(now())
+  updatedAt   DateTime          @updatedAt
+
+  @@unique([projectId, taskNumber])
+  @@index([projectId, status])
+}
+
+model ProjectMilestone {
+  id              String                 @id @default(cuid())
+  projectId       String
+  project         Project                @relation(fields: [projectId], references: [id])
+  milestoneNumber Int
+  title           String
+  description     String?
+  scheduledDate   DateTime
+  status          ProjectMilestoneStatus @default(SCHEDULED)
+  completedAt     DateTime?
+  createdAt       DateTime               @default(now())
+  updatedAt       DateTime               @updatedAt
+
+  @@unique([projectId, milestoneNumber])
+  @@index([projectId, status])
+}
+
+model ProjectTeamMember {
+  id        String   @id @default(cuid())
+  projectId String
+  project   Project  @relation(fields: [projectId], references: [id])
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  role      String
+  joinedAt  DateTime @default(now())
+  createdAt DateTime @default(now())
+
+  @@unique([projectId, userId])
+  @@index([projectId, role])
+}
+
+model ProjectNote {
+  id        String   @id @default(cuid())
+  projectId String
+  project   Project  @relation(fields: [projectId], references: [id])
+  authorId  String?
+  author    User?    @relation(fields: [authorId], references: [id])
+  content   String
+  createdAt DateTime @default(now())
+
+  @@index([projectId, createdAt])
+}
+
+model FundingProject {
+  id                      String                        @id @default(cuid())
+  title                   String
+  description             String
+  artistId                String
+  artist                  User                          @relation("FundingProjectOwner", fields: [artistId], references: [id])
+  artistName              String
+  category                ProjectCategory
+  goalAmount              Decimal                       @db.Decimal(18, 2)
+  currentAmount           Decimal                       @default(0) @db.Decimal(18, 2)
+  startDate               DateTime
+  endDate                 DateTime
+  status                  FundingProjectStatus          @default(PREPARING)
+  progress                Int                           @default(0)
+  daysLeft                Int                           @default(0)
+  image                   String?
+  type                    FundingProjectType?
+  tags                    String[]
+  isActive                Boolean                       @default(true)
+  isVerified              Boolean                       @default(false)
+  featured                Boolean                       @default(false)
+  revenueTotal            Decimal?                      @db.Decimal(18, 2)
+  revenuePlatformFeeRate  Float                         @default(0.05)
+  revenueArtistShareRate  Float                         @default(0.7)
+  revenueBackerShareRate  Float                         @default(0.25)
+  createdAt               DateTime                      @default(now())
+  updatedAt               DateTime                      @updatedAt
+
+  executionPlan           FundingProjectExecutionPlan?
+  stages                  FundingProjectStage[]
+  expenseRecords          FundingProjectExpenseRecord[]
+  revenueDistributions    FundingProjectDistribution[]
+  pledges                 Pledge[]
+  rewards                 FundingProjectReward[]
+  updates                 FundingProjectUpdate[]
+  payments                Payment[]
+
+  @@index([status, endDate])
+  @@index([category, status])
+  @@index([artistId, createdAt])
+}
+
+model FundingProjectExecutionPlan {
+  id         String          @id @default(cuid())
+  projectId  String          @unique
+  project    FundingProject  @relation(fields: [projectId], references: [id])
+  totalBudget Decimal        @db.Decimal(18, 2)
+  createdAt  DateTime        @default(now())
+  updatedAt  DateTime        @updatedAt
+
+  stages     FundingProjectStage[]
+}
+
+model FundingProjectStage {
+  id          String                 @id @default(cuid())
+  projectId   String
+  project     FundingProject         @relation(fields: [projectId], references: [id])
+  planId      String?
+  plan        FundingProjectExecutionPlan? @relation(fields: [planId], references: [id])
+  name        String
+  description String
+  budget      Decimal                @db.Decimal(18, 2)
+  startDate   DateTime
+  endDate     DateTime
+  status      FundingExecutionStatus @default(PLANNED)
+  progress    Int                    @default(0)
+  createdAt   DateTime               @default(now())
+  updatedAt   DateTime               @updatedAt
+
+  expenseRecords FundingProjectExpenseRecord[]
+
+  @@index([projectId, status])
+}
+
+model FundingProjectExpenseRecord {
+  id          String                  @id @default(cuid())
+  projectId   String
+  project     FundingProject          @relation(fields: [projectId], references: [id])
+  stageId     String?
+  stage       FundingProjectStage?    @relation(fields: [stageId], references: [id])
+  category    FundingExpenseCategory
+  title       String
+  description String
+  amount      Decimal                 @db.Decimal(18, 2)
+  receipt     String?
+  expenseDate DateTime
+  verified    Boolean                 @default(false)
+  createdAt   DateTime                @default(now())
+  updatedAt   DateTime                @updatedAt
+
+  @@index([projectId, category])
+  @@index([stageId])
+}
+
+model FundingProjectDistribution {
+  id             String                     @id @default(cuid())
+  projectId      String
+  project        FundingProject             @relation(fields: [projectId], references: [id])
+  backerId       String?
+  backer         User?                      @relation(fields: [backerId], references: [id])
+  pledgeId       String?
+  pledge        Pledge?                   @relation(fields: [pledgeId], references: [id])
+  userName       String?
+  originalAmount Decimal                    @db.Decimal(18, 2)
+  profitShare    Decimal                    @default(0) @db.Decimal(18, 2)
+  totalReturn    Decimal                    @default(0) @db.Decimal(18, 2)
+  distributedAt  DateTime?
+  status         FundingDistributionStatus  @default(WAITING)
+  createdAt      DateTime                   @default(now())
+  updatedAt      DateTime                   @updatedAt
+
+  @@index([projectId, status])
+  @@index([backerId, projectId])
+  @@index([pledgeId])
+}
+
+model Pledge {
+  id          String       @id @default(cuid())
+  projectId   String
+  project     FundingProject @relation(fields: [projectId], references: [id])
+  userId      String?
+  user        User?        @relation(fields: [userId], references: [id])
+  userName    String?
+  amount      Decimal      @db.Decimal(18, 2)
+  rewardId    String?
+  reward      FundingProjectReward? @relation(fields: [rewardId], references: [id])
+  backedAt    DateTime     @default(now())
+  isAnonymous Boolean      @default(false)
+  message     String?
+  createdAt   DateTime     @default(now())
+
+  payments    Payment[]
+  distributions FundingProjectDistribution[]
+
+  @@index([projectId, backedAt])
+  @@index([projectId, userId])
+}
+
+model FundingProjectReward {
+  id                String                 @id @default(cuid())
+  projectId         String
+  project           FundingProject         @relation(fields: [projectId], references: [id])
+  title             String
+  description       String
+  amount            Decimal                @db.Decimal(18, 2)
+  claimed           Int                    @default(0)
+  maxClaim          Int?
+  estimatedDelivery DateTime?
+  createdAt         DateTime               @default(now())
+  updatedAt         DateTime               @updatedAt
+
+  pledges Pledge[]
+  payments Payment[]
+
+  @@index([projectId, amount])
+}
+
+model FundingProjectUpdate {
+  id        String             @id @default(cuid())
+  projectId String
+  project   FundingProject     @relation(fields: [projectId], references: [id])
+  title     String
+  content   String
+  type      FundingUpdateType  @default(GENERAL)
+  createdAt DateTime           @default(now())
+
+  @@index([projectId, type])
+}
+
+model Payment {
+  id              String           @id @default(cuid())
+  paymentId       String           @unique
+  orderId         String           @unique
+  projectId       String
+  project         FundingProject   @relation(fields: [projectId], references: [id])
+  backerId        String
+  backer          User             @relation("PaymentBacker", fields: [backerId], references: [id])
+  backerName      String
+  backerEmail     String
+  backerPhone     String
+  backerAddress   String?
+  rewardId        String?
+  reward          FundingProjectReward? @relation(fields: [rewardId], references: [id])
+  rewardName      String?
+  pledgeId        String?
+  pledge          Pledge?       @relation(fields: [pledgeId], references: [id])
+  amount          Decimal          @db.Decimal(18, 2)
+  paymentMethod   PaymentMethod
+  paymentProvider PaymentProvider  @default(TOSS)
+  status          PaymentStatus    @default(PENDING)
+  transactionId   String?
+  paymentKey      String?
+  message         String?
+  createdAt       DateTime         @default(now())
+  completedAt     DateTime?
+  cancelledAt     DateTime?
+  refundedAt      DateTime?
+  refundId        String?
+  refundAmount    Decimal          @default(0) @db.Decimal(18, 2)
+  refundReason    String?
+  metadata        Json?
+  updatedAt       DateTime         @updatedAt
+
+  @@index([projectId, status])
+  @@index([backerEmail, projectId])
+  @@index([status, createdAt])
+  @@index([backerId, createdAt])
+  @@index([pledgeId])
+}
+
+model CommunityPost {
+  id         String                 @id @default(cuid())
+  title      String
+  content    String
+  authorId   String
+  author     User                   @relation(fields: [authorId], references: [id])
+  authorName String
+  category   CommunityPostCategory
+  isReported Boolean                @default(false)
+  deletedAt  DateTime?
+  tags       String[]
+  images     String[]
+  isActive   Boolean                @default(true)
+  viewCount  Int                    @default(0)
+  createdAt  DateTime               @default(now())
+  updatedAt  DateTime               @updatedAt
+
+  comments   CommunityPostComment[]
+  reactions  CommunityPostReaction[]
+  reports    CommunityPostReport[]
+
+  @@index([category, createdAt])
+  @@index([authorId, createdAt])
+  @@index([title])
+  @@index([content])
+}
+
+model CommunityPostComment {
+  id         String         @id @default(cuid())
+  postId     String
+  post       CommunityPost  @relation(fields: [postId], references: [id])
+  authorId   String
+  author     User           @relation(fields: [authorId], references: [id])
+  authorName String
+  content    String
+  createdAt  DateTime       @default(now())
+
+  replies    CommunityPostReply[]
+
+  @@index([postId, createdAt])
+}
+
+model CommunityPostReply {
+  id         String        @id @default(cuid())
+  commentId  String
+  comment    CommunityPostComment @relation(fields: [commentId], references: [id])
+  authorId   String
+  author     User          @relation(fields: [authorId], references: [id])
+  authorName String
+  content    String
+  createdAt  DateTime      @default(now())
+
+  @@index([commentId, createdAt])
+}
+
+model CommunityPostReaction {
+  id        String        @id @default(cuid())
+  postId    String
+  post      CommunityPost @relation(fields: [postId], references: [id])
+  userId    String
+  user      User          @relation(fields: [userId], references: [id])
+  type      ReactionType
+  createdAt DateTime      @default(now())
+
+  @@unique([postId, userId, type])
+}
+
+model CommunityPostReport {
+  id         String        @id @default(cuid())
+  postId     String
+  post       CommunityPost @relation(fields: [postId], references: [id])
+  reporterId String
+  reporter   User          @relation(fields: [reporterId], references: [id])
+  reason     String
+  reportedAt DateTime      @default(now())
+
+  @@index([postId, reportedAt])
+}
+
+model Track {
+  id            String      @id @default(cuid())
+  title         String
+  artistId      String
+  artist        User        @relation(fields: [artistId], references: [id])
+  artistName    String
+  album         String
+  duration      String
+  genre         TrackGenre
+  releaseDate   DateTime
+  plays         Int         @default(0)
+  image         String?
+  audioUrl      String?
+  lyrics        String?
+  credits       Json?
+  tags          String[]
+  isActive      Boolean     @default(true)
+  isPublic      Boolean     @default(true)
+  isExplicit    Boolean     @default(false)
+  bpm           Int?
+  key           MusicKey?
+  moods         MusicMood[]
+  instruments   String[]
+  language      String       @default("한국어")
+  copyright     String?
+  license       LicenseType  @default(ALL_RIGHTS_RESERVED)
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
+
+  likes         TrackLike[]
+
+  @@index([artistId, releaseDate])
+  @@index([genre, releaseDate])
+  @@index([album, releaseDate])
+}
+
+model TrackLike {
+  id        String   @id @default(cuid())
+  trackId   String
+  track     Track    @relation(fields: [trackId], references: [id])
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  createdAt DateTime @default(now())
+
+  @@unique([trackId, userId])
+  @@index([userId, createdAt])
+}
+
+model Event {
+  id                String        @id @default(cuid())
+  title             String
+  description       String
+  category          EventCategory
+  startDate         DateTime
+  endDate           DateTime
+  time              String
+  location          String
+  address           String?
+  maxAttendees      Int
+  currentAttendees  Int           @default(0)
+  image             String?
+  status            EventStatus   @default(SCHEDULED)
+  isActive          Boolean       @default(true)
+  createdById       String
+  createdBy         User          @relation(fields: [createdById], references: [id])
+  tags              String[]
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
+
+  attendees         EventAttendee[]
+  tickets           EventTicket[]
+  performers        EventPerformer[]
+
+  @@index([startDate, status])
+  @@index([category, startDate])
+  @@index([location, startDate])
+}
+
+model EventAttendee {
+  id           String   @id @default(cuid())
+  eventId      String
+  event        Event    @relation(fields: [eventId], references: [id])
+  userId       String?
+  user         User?    @relation(fields: [userId], references: [id])
+  userName     String?
+  registeredAt DateTime @default(now())
+
+  @@index([eventId, registeredAt])
+  @@unique([eventId, userId])
+}
+
+model EventTicket {
+  id        String          @id @default(cuid())
+  eventId   String
+  event     Event           @relation(fields: [eventId], references: [id])
+  type      EventTicketType
+  price     Decimal         @db.Decimal(18, 2)
+  available Int
+  sold      Int             @default(0)
+
+  @@index([eventId, type])
+}
+
+model EventPerformer {
+  id          String @id @default(cuid())
+  eventId     String
+  event       Event   @relation(fields: [eventId], references: [id])
+  name        String
+  genre       String?
+  description String?
+
+  @@index([eventId, name])
+}
+
+model LiveStream {
+  id               String            @id @default(cuid())
+  title            String
+  description      String
+  artistId         String
+  artist           User              @relation(fields: [artistId], references: [id])
+  artistName       String
+  category         LiveStreamCategory
+  thumbnail        String?
+  streamUrl        String?
+  isLive           Boolean           @default(false)
+  status           LiveStreamStatus  @default(SCHEDULED)
+  scheduledAt      DateTime?
+  startedAt        DateTime?
+  endedAt          DateTime?
+  duration         Int               @default(0)
+  viewerCount      Int               @default(0)
+  maxViewers       Int               @default(0)
+  tags             String[]
+  isActive         Boolean           @default(true)
+  isPrivate        Boolean           @default(false)
+  chatEnabled      Boolean           @default(true)
+  recordingEnabled Boolean           @default(false)
+  recordingUrl     String?
+  createdAt        DateTime          @default(now())
+  updatedAt        DateTime          @updatedAt
+
+  allowedViewers   LiveStreamAccess[]
+
+  @@index([status, startedAt])
+  @@index([artistId, createdAt])
+  @@index([category, status])
+}
+
+model LiveStreamAccess {
+  id          String     @id @default(cuid())
+  liveStreamId String
+  liveStream  LiveStream @relation(fields: [liveStreamId], references: [id])
+  userId      String
+  user        User       @relation(fields: [userId], references: [id])
+  createdAt   DateTime   @default(now())
+
+  @@unique([liveStreamId, userId])
+}
+
+model Artwork {
+  id          String         @id @default(cuid())
+  title       String
+  artistId    String
+  artist      User           @relation(fields: [artistId], references: [id])
+  category    ArtworkCategory
+  type        ArtworkType
+  thumbnail   String
+  description String
+  duration    String?
+  dimensions  String?
+  plays       Int            @default(0)
+  views       Int            @default(0)
+  likes       Int            @default(0)
+  tags        String[]
+  status      ArtworkStatus  @default(PUBLISHED)
+  metadata    Json?
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  @@index([artistId, category])
+  @@index([category, createdAt])
+  @@index([likes, createdAt])
+}
+
+model Category {
+  id        String   @id
+  label     String
+  icon      String?
+  isActive  Boolean  @default(true)
+  order     Int      @default(0)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model Notification {
+  id        String           @id @default(cuid())
+  userId    String
+  user      User             @relation(fields: [userId], references: [id])
+  type      NotificationType
+  title     String
+  message   String
+  read      Boolean          @default(false)
+  url       String?
+  data      Json?
+  isActive  Boolean          @default(true)
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  @@index([userId, createdAt])
+  @@index([userId, read])
+}
+
+model RevenueDistribution {
+  id                 String             @id @default(cuid())
+  projectId          String
+  project            FundingProject     @relation(fields: [projectId], references: [id])
+  creatorId          String
+  creator            User               @relation("RevenueCreator", fields: [creatorId], references: [id])
+  creatorName        String
+  managerId          String?
+  manager            User?              @relation("RevenueManager", fields: [managerId], references: [id])
+  totalRevenue       Decimal            @db.Decimal(18, 2)
+  platformFee        Decimal            @db.Decimal(18, 2)
+  creatorRevenue     Decimal            @db.Decimal(18, 2)
+  platformFeeRate    Float              @default(0.05)
+  creatorRevenueRate Float              @default(0.95)
+  status             DistributionStatus @default(PENDING)
+  distributionDate   DateTime
+  processedAt        DateTime?
+  payoutId           String?
+  payoutStatus       DistributionStatus @default(PENDING)
+  payoutProcessedAt  DateTime?
+  failureReason      String?
+  retryCount         Int                @default(0)
+  lastRetryAt        DateTime?
+  backerCount        Int
+  averageBackAmount  Decimal            @db.Decimal(18, 2)
+  metadata           Json?
+  createdAt          DateTime           @default(now())
+  updatedAt          DateTime           @updatedAt
+
+  creatorPayouts     CreatorPayout[]
+
+  @@index([projectId, status])
+  @@index([creatorId, status])
+  @@index([distributionDate])
+  @@index([status, distributionDate])
+}
+
+model CreatorPayout {
+  id                     String             @id @default(cuid())
+  creatorId              String
+  creator                User               @relation(fields: [creatorId], references: [id])
+  creatorName            String
+  projectId              String
+  project                FundingProject     @relation(fields: [projectId], references: [id])
+  projectTitle           String
+  revenueDistributionId  String
+  revenueDistribution    RevenueDistribution @relation(fields: [revenueDistributionId], references: [id])
+  payoutId               String             @unique
+  amount                 Decimal            @db.Decimal(18, 2)
+  bankCode               String
+  bankName               String
+  accountNumber          String
+  accountHolder          String
+  status                 DistributionStatus @default(PENDING)
+  requestedAt            DateTime           @default(now())
+  processedAt            DateTime?
+  completedAt            DateTime?
+  bankTransactionId      String?
+  bankResponseCode       String?
+  bankResponseMessage    String?
+  failureReason          String?
+  retryCount             Int                @default(0)
+  lastRetryAt            DateTime?
+  processingFee          Decimal            @default(0) @db.Decimal(18, 2)
+  netAmount              Decimal            @db.Decimal(18, 2)
+  metadata               Json?
+  createdAt              DateTime           @default(now())
+  updatedAt              DateTime           @updatedAt
+
+  @@index([creatorId, status])
+  @@index([projectId, status])
+  @@index([requestedAt])
+  @@index([status, requestedAt])
+}
+

--- a/server/constants/enums.js
+++ b/server/constants/enums.js
@@ -1,213 +1,80 @@
+const { Prisma } = require('@prisma/client');
+
+const mapEnum = enumObject => ({ ...enumObject });
+
 // 시스템 전체에서 사용되는 enum 값들을 중앙 집중식으로 관리
 const ENUMS = {
   // 사용자 역할
-  USER_ROLES: {
-    ARTIST: 'artist',
-    ADMIN: 'admin',
-    FAN: 'fan',
-  },
+  USER_ROLES: mapEnum(Prisma.UserRole),
 
   // 아티스트 카테고리
-  ARTIST_CATEGORIES: {
-    MUSIC: '음악',
-    ART: '미술',
-    VIDEO: '영상',
-    LITERATURE: '문학',
-    CRAFT: '공예',
-    DESIGN: '디자인',
-    OTHER: '기타',
-  },
+  ARTIST_CATEGORIES: mapEnum(Prisma.ArtistCategory),
 
   // 아티스트 장르 (음악)
-  ARTIST_GENRES: {
-    POP: '팝',
-    ROCK: '록',
-    RNB: 'R&B',
-    JAZZ: '재즈',
-    CLASSICAL: '클래식',
-    HIPHOP: '힙합',
-    ELECTRONIC: '일렉트로닉',
-    INDIE: '인디',
-    ALTERNATIVE: '얼터너티브',
-    COUNTRY: '컨트리',
-    REGGAE: '레게',
-    BLUES: '블루스',
-    SOUL: '소울',
-    PUNK: '펑크',
-    METAL: '메탈',
-    OTHER: '기타',
-  },
+  ARTIST_GENRES: mapEnum(Prisma.ArtistGenre),
 
   // 프로젝트 카테고리
-  PROJECT_CATEGORIES: {
-    MUSIC: '음악',
-    VIDEO: '비디오',
-    PERFORMANCE: '공연',
-    BOOK: '도서',
-    GAME: '게임',
-    OTHER: '기타',
-  },
+  PROJECT_CATEGORIES: mapEnum(Prisma.ProjectCategory),
 
   // 프로젝트 상태
-  PROJECT_STATUSES: {
-    PLANNING: '계획중',
-    IN_PROGRESS: '진행중',
-    COMPLETED: '완료',
-    PENDING: '보류',
-    CANCELLED: '취소',
-  },
+  PROJECT_STATUSES: mapEnum(Prisma.ProjectStatus),
 
   // 태스크 상태
-  TASK_STATUSES: {
-    WAITING: '대기',
-    IN_PROGRESS: '진행중',
-    COMPLETED: '완료',
-    PENDING: '보류',
-  },
+  TASK_STATUSES: mapEnum(Prisma.ProjectTaskStatus),
 
   // 이벤트 카테고리
-  EVENT_CATEGORIES: {
-    FESTIVAL: '축제',
-    PERFORMANCE: '공연',
-    COMPETITION: '경연',
-    WORKSHOP: '워크샵',
-    SEMINAR: '세미나',
-    OTHER: '기타',
-  },
+  EVENT_CATEGORIES: mapEnum(Prisma.EventCategory),
 
   // 이벤트 상태
-  EVENT_STATUSES: {
-    SCHEDULED: '예정',
-    IN_PROGRESS: '진행중',
-    COMPLETED: '완료',
-    CANCELLED: '취소',
-  },
+  EVENT_STATUSES: mapEnum(Prisma.EventStatus),
 
   // 라이브스트림 카테고리
-  LIVESTREAM_CATEGORIES: {
-    MUSIC: '음악',
-    PERFORMANCE: '공연',
-    TALK: '토크',
-    WORKSHOP: '워크샵',
-    OTHER: '기타',
-  },
+  LIVESTREAM_CATEGORIES: mapEnum(Prisma.LiveStreamCategory),
 
   // 라이브스트림 상태
-  LIVESTREAM_STATUSES: {
-    SCHEDULED: '예정',
-    LIVE: '라이브',
-    ENDED: '종료',
-    CANCELLED: '취소',
-  },
+  LIVESTREAM_STATUSES: mapEnum(Prisma.LiveStreamStatus),
 
   // 펀딩 프로젝트 상태
-  FUNDING_PROJECT_STATUSES: {
-    PREPARING: '준비중',
-    IN_PROGRESS: '진행중',
-    SUCCESS: '성공',
-    FAILED: '실패',
-    CANCELLED: '취소',
-    EXECUTING: '집행중',
-    COMPLETED: '완료',
-  },
+  FUNDING_PROJECT_STATUSES: mapEnum(Prisma.FundingProjectStatus),
 
-  // 수익 분배 상태
-  DISTRIBUTION_STATUSES: {
-    WAITING: '대기',
-    DISTRIBUTED: '분배완료',
-    PAID: '지급완료',
-  },
+  // 수익 분배 상태 (펀딩 프로젝트 내부 분배용)
+  DISTRIBUTION_STATUSES: mapEnum(Prisma.FundingDistributionStatus),
+
+  // 수익 분배 엔티티 상태
+  REVENUE_DISTRIBUTION_STATUSES: mapEnum(Prisma.DistributionStatus),
 
   // 비용 카테고리
-  EXPENSE_CATEGORIES: {
-    LABOR: '인건비',
-    MATERIAL: '재료비',
-    EQUIPMENT: '장비비',
-    MARKETING: '마케팅비',
-    OTHER: '기타',
-  },
+  EXPENSE_CATEGORIES: mapEnum(Prisma.FundingExpenseCategory),
 
   // 트랙 장르
-  TRACK_GENRES: {
-    INDIE_POP: '인디팝',
-    ROCK: '록',
-    ACOUSTIC: '어쿠스틱',
-    JAZZ: '재즈',
-    CLASSICAL: '클래식',
-    ELECTRONIC: '일렉트로닉',
-    HIPHOP: '힙합',
-    RNB: 'R&B',
-    OTHER: '기타',
-  },
+  TRACK_GENRES: mapEnum(Prisma.TrackGenre),
 
   // 음악 키
-  MUSIC_KEYS: ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'],
+  MUSIC_KEYS: Object.values(Prisma.MusicKey),
 
   // 음악 분위기
-  MUSIC_MOODS: {
-    EXCITING: '신나는',
-    EMOTIONAL: '감성적인',
-    CALM: '잔잔한',
-    INTENSE: '강렬한',
-    MELANCHOLY: '우울한',
-    HOPEFUL: '희망적인',
-    ROMANTIC: '로맨틱한',
-    MYSTERIOUS: '신비로운',
-  },
+  MUSIC_MOODS: mapEnum(Prisma.MusicMood),
 
   // 라이센스
-  LICENSES: {
-    ALL_RIGHTS_RESERVED: 'All Rights Reserved',
-    CREATIVE_COMMONS: 'Creative Commons',
-    PUBLIC_DOMAIN: 'Public Domain',
-  },
+  LICENSES: mapEnum(Prisma.LicenseType),
 
   // 아트워크 타입
-  ARTWORK_TYPES: {
-    AUDIO: 'audio',
-    IMAGE: 'image',
-    VIDEO: 'video',
-    TEXT: 'text',
-  },
+  ARTWORK_TYPES: mapEnum(Prisma.ArtworkType),
 
   // 아트워크 상태
-  ARTWORK_STATUSES: {
-    DRAFT: 'draft',
-    PUBLISHED: 'published',
-    ARCHIVED: 'archived',
-  },
+  ARTWORK_STATUSES: mapEnum(Prisma.ArtworkStatus),
 
   // 이벤트 티켓 타입
-  EVENT_TICKET_TYPES: {
-    REGULAR: '일반',
-    VIP: 'VIP',
-    EARLY_BIRD: '얼리버드',
-    STUDENT: '학생',
-  },
+  EVENT_TICKET_TYPES: mapEnum(Prisma.EventTicketType),
 
   // 마일스톤 상태
-  MILESTONE_STATUSES: {
-    SCHEDULED: '예정',
-    IN_PROGRESS: '진행중',
-    COMPLETED: '완료',
-    DELAYED: '지연',
-  },
+  MILESTONE_STATUSES: mapEnum(Prisma.ProjectMilestoneStatus),
 
   // 우선순위
-  PRIORITIES: {
-    LOW: '낮음',
-    MEDIUM: '보통',
-    HIGH: '높음',
-    URGENT: '긴급',
-  },
+  PRIORITIES: mapEnum(Prisma.PriorityLevel),
 
   // 펀딩 프로젝트 타입
-  FUNDING_PROJECT_TYPES: {
-    REGULAR: '일반',
-    EXECUTION_IN_PROGRESS: '집행진행',
-    EXPENSE_PUBLIC: '비용공개',
-    REVENUE_DISTRIBUTION: '수익분배',
-  },
+  FUNDING_PROJECT_TYPES: mapEnum(Prisma.FundingProjectType),
 };
 
 // CSV 헤더 상수


### PR DESCRIPTION
## Summary
- introduce a PostgreSQL-based Prisma schema that models users, artists, projects, funding flows, community content, events, and media with normalized tables and indexes
- document service-layer view models for replacing former Mongoose virtual fields and hooks
- refactor shared enum constants to source values from the generated Prisma client for front/back-end reuse

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6a6864224832694605f9eadf65a1f