### PR TITLE
feat: align shared types with prisma enums

### DIFF
--- a/DATABASE_CONFIG.md
+++ b/DATABASE_CONFIG.md
@@ -1,82 +1,42 @@
-# 데이터베이스 설정
+# 데이터베이스 설정 (PostgreSQL + Prisma)
 
-## 🗄️ MongoDB URI
+## 📦 개요
 
-### 프로덕션 데이터베이스 (Railway)
+프로젝트는 PostgreSQL을 표준 데이터베이스로 사용하며 Prisma ORM을 통해 스키마와 타입을 관리합니다. 기존 MongoDB 컬렉션 기반 모델은 `server/models`에 남아있지만, 새로운 개발은 `prisma/schema.prisma`를 기준으로 진행합니다.
 
-```
-mongodb+srv://rmwl2356_db_user:f8NaljAJhfZpTc7J@collaboreum-cluster.tdwqiwn.mongodb.net/?retryWrites=true&w=majority&appName=collaboreum-cluster
-```
+## 🔌 연결 정보
 
-### 연결 정보
+- **기본 호스트**: `localhost`
+- **기본 포트**: `5432`
+- **기본 데이터베이스명**: `collaboreum`
+- **권장 인코딩**: `UTF8`
+- **드라이버**: PostgreSQL (Prisma `postgresql` provider)
 
-- **호스트**: Railway MongoDB Atlas 클러스터
-- **데이터베이스명**: test
-- **컬렉션 수**: 14개
-- **상태**: ✅ 연결 성공
+로컬 개발 시 `docker compose` 또는 로컬 PostgreSQL 인스턴스를 사용하세요.
 
-## 📊 현재 데이터 현황
+## 🔐 환경 변수
 
-### 컬렉션 목록
-
-1. `events` - 이벤트 데이터
-2. `livestreams` - 라이브 스트림 데이터
-3. `users` - 사용자 데이터
-4. `payments` - 결제 데이터
-5. `artists` - 아티스트 프로필 데이터
-6. `fundingprojects` - 펀딩 프로젝트 데이터
-7. `artworks` - 작품 데이터
-8. `communityposts` - 커뮤니티 게시글 데이터
-9. `projects` - 일반 프로젝트 데이터
-10. `creatorpayouts` - 크리에이터 지급 데이터
-11. `revenuedistributions` - 수익 분배 데이터
-12. `tracks` - 트랙 데이터
-13. `notifications` - 알림 데이터
-14. `categories` - 카테고리 데이터
-
-### 데이터 통계
-
-- **커뮤니티 게시글**: 3개
-- **사용자**: 2명
-- **아티스트**: 1명
-
-## 🔧 연결 설정
-
-### 환경 변수
+루트 `.env` 또는 `server/.env`에 다음 값을 정의합니다.
 
 ```bash
-MONGODB_URI=mongodb+srv://rmwl2356_db_user:f8NaljAJhfZpTc7J@collaboreum-cluster.tdwqiwn.mongodb.net/?retryWrites=true&w=majority&appName=collaboreum-cluster
+DATABASE_URL="postgresql://<USER>:<PASSWORD>@<HOST>:<PORT>/<DATABASE>?schema=public"
 ```
 
-### 연결 옵션
+> ✅ `DATABASE_URL`은 Prisma와 서버 레이어가 공유하므로, 환경 별로 (개발/스테이징/프로덕션) 각기 다른 값을 설정하세요.
 
-```javascript
-const mongoose = require('mongoose');
+## 🛠️ Prisma 워크플로우
 
-await mongoose.connect(process.env.MONGODB_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-});
-```
+1. **스키마 업데이트**: `prisma/schema.prisma`에서 모델과 enum을 수정합니다.
+2. **타입 생성**: 루트에서 `npm run prisma:generate`를 실행하면 Prisma Client와 타입이 생성됩니다.
+3. **타입 공유**: 프런트엔드는 `src/shared/types`에서 Prisma enum과 타입을 재사용합니다.
+4. **마이그레이션 (추가 예정)**: 현재는 초기 스키마 정의만 포함되어 있으며, 추후 `prisma migrate` 기반 마이그레이션이 추가될 예정입니다.
 
-## 📝 주의사항
+## 📄 참고 자료
 
-1. **보안**: URI에 포함된 비밀번호는 절대 공개하지 마세요
-2. **백업**: 정기적인 데이터 백업을 권장합니다
-3. **모니터링**: Railway 대시보드에서 연결 상태를 모니터링하세요
-4. **확장성**: 사용자 증가에 따라 클러스터 확장을 고려하세요
+- [Prisma Docs](https://www.prisma.io/docs/)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+- `src/shared/types/index.ts` — 프런트엔드에서 사용하는 Prisma 기반 타입 정의
 
-## 🚀 배포 시 고려사항
+## 🧭 레거시 참고
 
-- 모든 CRUD 작업은 이 URI를 사용합니다
-- 로컬 개발 시에도 이 데이터베이스를 사용할 수 있습니다
-- 프로덕션 환경에서는 연결 풀링을 고려하세요
-
-## 📞 문제 해결
-
-연결 문제가 발생하면:
-
-1. Railway 대시보드에서 클러스터 상태 확인
-2. 네트워크 연결 확인
-3. 인증 정보 확인
-4. 방화벽 설정 확인
+`server/models`와 여러 스크립트는 MongoDB/Mongoose 기반 레거시 코드입니다. 점진적으로 Prisma + PostgreSQL로 이전할 계획이며, 신규 기능은 반드시 Prisma 모델을 기준으로 설계해 주세요.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 ### Backend
 
 - **Node.js** + **Express.js**
-- **MongoDB** + **Mongoose** ODM
+- **PostgreSQL** + **Prisma ORM**
 - **JWT** 인증 시스템
 - **Multer** 파일 업로드
 
@@ -88,9 +88,9 @@ Collaboreum MVP Platform/
 │   ├── services/                 # API 서비스
 │   ├── types/                    # TypeScript 타입 정의
 │   └── utils/                    # 유틸리티 함수
+├── prisma/                       # Prisma 스키마 및 마이그레이션 정의
 ├── server/                       # Backend 서버 코드
-│   ├── models/                   # MongoDB 모델
-│   │   └── FundingProject.js     # 펀딩 프로젝트 모델
+│   ├── models/                   # (레거시) MongoDB 모델
 │   ├── routes/                   # API 라우트
 │   │   └── funding.js            # 펀딩 관련 API
 │   ├── middleware/               # 미들웨어
@@ -149,14 +149,15 @@ cd ..
 cp server/env.example server/.env
 
 # 필요한 환경 변수 설정
-MONGODB_URI=your_mongodb_connection_string
+DATABASE_URL=postgresql://user:password@localhost:5432/collaboreum
 JWT_SECRET=your_jwt_secret
 PORT=5000
 ```
 
 ### 4. 데이터베이스 설정
 
-MongoDB 데이터베이스를 설정하고 연결 문자열을 환경 변수에 추가하세요.
+PostgreSQL 인스턴스를 준비하고 `DATABASE_URL` 환경 변수에 연결 문자열을 설정하세요.
+Prisma 스키마가 변경되면 `npm run prisma:generate`를 실행해 공유 타입을 갱신합니다.
 
 ### 5. 개발 서버 실행
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@hookform/resolvers": "^3.3.2",
+    "@prisma/client": "^5.22.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -76,6 +77,7 @@
     "cypress:ci": "echo 'Cypress not installed'",
     "env:verify": "node scripts/verify-env.js",
     "openapi:gen": "openapi-typescript ./openapi.yaml -o ./src/types/api.d.ts || echo 'OpenAPI file not found'",
+    "prisma:generate": "prisma generate",
     "check:types": "tsc -p tsconfig.json --noEmit",
     "check:build": "vite build",
     "check:lint": "eslint \"src/**/*.{js,jsx}\" --max-warnings 0",
@@ -159,6 +161,7 @@
     "postcss": "^8.4.31",
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.8",
+    "prisma": "^5.22.0",
     "semgrep": "^1.0.0",
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,281 @@
+// Prisma schema aligned with Collaboreum domain models
+// Datasource definition assumes PostgreSQL with DATABASE_URL environment variable.
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+enum UserRole {
+  admin
+  artist
+  fan
+}
+
+enum NotificationType {
+  info
+  success
+  warning
+  error
+  funding_update
+  project_update
+  community_update
+}
+
+enum FundingProjectStatus {
+  draft
+  collecting
+  succeeded
+  failed
+  executing
+  distributing
+  closed
+}
+
+enum PledgeStatus {
+  pending
+  authorized
+  captured
+  refunded
+  failed
+  cancelled
+}
+
+enum ExecutionStatus {
+  pending
+  approved
+  rejected
+  completed
+}
+
+enum DistributionStatus {
+  pending
+  calculated
+  executed
+  failed
+}
+
+enum DistributionRuleType {
+  owner
+  platform
+  artist
+  contributor
+  custom
+}
+
+enum DistributionItemStatus {
+  pending
+  processing
+  completed
+  failed
+}
+
+model User {
+  id          String         @id @default(uuid())
+  email       String         @unique
+  username    String         @unique
+  displayName String
+  name        String
+  role        UserRole       @default(fan)
+  avatar      String?
+  bio         String?
+  isActive    Boolean        @default(true)
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  notifications Notification[]
+  projects       FundingProject[] @relation("ProjectOwner")
+  pledges        Pledge[]
+}
+
+model Notification {
+  id        String          @id @default(uuid())
+  userId    String
+  title     String
+  message   String
+  type      NotificationType @default(info)
+  isRead    Boolean          @default(false)
+  data      Json?
+  createdAt DateTime         @default(now())
+  updatedAt DateTime         @updatedAt
+
+  user User @relation(fields: [userId], references: [id])
+}
+
+model Category {
+  id          String           @id @default(uuid())
+  name        String
+  slug        String           @unique
+  description String?
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  projects FundingProject[]
+}
+
+model FundingProject {
+  id               String                @id @default(uuid())
+  title            String
+  description      String
+  shortDescription String?
+  targetAmount     Int
+  currentAmount    Int                 @default(0)
+  status           FundingProjectStatus @default(draft)
+  startDate        DateTime?
+  endDate          DateTime?
+  ownerId          String?
+  categoryId       String?
+  images           String[]             @default([])
+  tags             String[]             @default([])
+  progress         Int                  @default(0)
+  backerCount      Int                  @default(0)
+  isActive         Boolean              @default(true)
+  isFeatured       Boolean              @default(false)
+  metadata         Json?
+  createdAt        DateTime             @default(now())
+  updatedAt        DateTime             @updatedAt
+
+  owner      User?     @relation("ProjectOwner", fields: [ownerId], references: [id])
+  category   Category? @relation(fields: [categoryId], references: [id])
+  rewards    Reward[]
+  pledges    Pledge[]
+  executions Execution[]
+  distributions Distribution[]
+}
+
+model Reward {
+  id            String          @id @default(uuid())
+  projectId     String
+  title         String
+  description   String
+  amount        Int
+  deliveryDate  DateTime?
+  stock         Int
+  soldCount     Int             @default(0)
+  isLimited     Boolean         @default(false)
+  isActive      Boolean         @default(true)
+  images        String[]        @default([])
+  metadata      Json?
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+
+  project FundingProject @relation(fields: [projectId], references: [id])
+  pledges Pledge[]
+}
+
+model Pledge {
+  id             String       @id @default(uuid())
+  projectId      String
+  userId         String
+  rewardId       String?
+  amount         Int
+  status         PledgeStatus @default(pending)
+  paymentMethod  String
+  paymentId      String?
+  idempotencyKey String       @unique
+  authorizedAt   DateTime?
+  capturedAt     DateTime?
+  refundedAt     DateTime?
+  refundAmount   Int?
+  refundReason   String?
+  metadata       Json?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  project FundingProject @relation(fields: [projectId], references: [id])
+  user    User           @relation(fields: [userId], references: [id])
+  reward  Reward?        @relation(fields: [rewardId], references: [id])
+}
+
+model Execution {
+  id           String          @id @default(uuid())
+  projectId    String
+  title        String
+  description  String
+  budgetAmount Int
+  actualAmount Int?
+  status       ExecutionStatus @default(pending)
+  approvedBy   String?
+  approvedAt   DateTime?
+  metadata     Json?
+  createdAt    DateTime        @default(now())
+  updatedAt    DateTime        @updatedAt
+
+  project  FundingProject @relation(fields: [projectId], references: [id])
+  receipts Receipt[]
+}
+
+model Receipt {
+  id           String   @id @default(uuid())
+  executionId  String
+  filename     String
+  originalName String
+  mimeType     String
+  size         Int
+  url          String
+  amount       Int
+  date         DateTime
+  description  String
+  isVerified   Boolean  @default(false)
+  verifiedBy   String?
+  verifiedAt   DateTime?
+  ocrData      Json?
+  metadata     Json?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  execution Execution @relation(fields: [executionId], references: [id])
+}
+
+model Distribution {
+  id          String             @id @default(uuid())
+  projectId   String
+  totalAmount Int
+  status      DistributionStatus @default(pending)
+  executedAt  DateTime?
+  executedBy  String?
+  metadata    Json?
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+
+  project FundingProject   @relation(fields: [projectId], references: [id])
+  rules   DistributionRule[]
+  items   DistributionItem[]
+}
+
+model DistributionRule {
+  id             String                @id @default(uuid())
+  distributionId String
+  type           DistributionRuleType
+  percentage     Float?
+  fixedAmount    Int?
+  recipient      String
+  description    String
+  priority       Int
+  metadata       Json?
+  createdAt      DateTime             @default(now())
+  updatedAt      DateTime             @updatedAt
+
+  distribution Distribution @relation(fields: [distributionId], references: [id])
+  items        DistributionItem[]
+}
+
+model DistributionItem {
+  id             String                 @id @default(uuid())
+  distributionId String
+  ruleId         String?
+  recipientId    String
+  amount         Int
+  status         DistributionItemStatus @default(pending)
+  executedAt     DateTime?
+  transactionId  String?
+  metadata       Json?
+  createdAt      DateTime              @default(now())
+  updatedAt      DateTime              @updatedAt
+
+  distribution Distribution    @relation(fields: [distributionId], references: [id])
+  rule         DistributionRule? @relation(fields: [ruleId], references: [id])
+}

--- a/src/components/Header/MobileMenu.tsx
+++ b/src/components/Header/MobileMenu.tsx
@@ -4,7 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '../ui/avatar';
 import { User, Search, Bell } from 'lucide-react';
 import { NAVIGATION_ITEMS } from './constants';
 import { getRoleBadge, getUserAvatar } from './utils';
-import { UserRole } from '../../utils/auth';
+import type { UserRole } from '@/shared/types';
 
 interface MobileMenuProps {
   isLoggedIn: boolean;

--- a/src/components/Header/utils.tsx
+++ b/src/components/Header/utils.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Badge } from '../ui/badge';
 import { USER_AVATARS } from './constants';
-
-import { UserRole } from '../../utils/auth';
+import type { UserRole } from '@/shared/types';
 
 export const getRoleBadge = (userRole: UserRole) => {
   switch (userRole) {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import type { UserRole } from '@/shared/types';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
   fallback?: React.ReactNode;
   requireAuth?: boolean;
-  requiredRole?: 'artist' | 'admin' | 'fan';
+  requiredRole?: UserRole;
   onNavigateToLogin?: () => void;
   onNavigateToSignup?: () => void;
 }
@@ -145,7 +146,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 };
 
 // 역할 표시명 변환 함수
-const getRoleDisplayName = (role: string): string => {
+const getRoleDisplayName = (role: UserRole): string => {
   switch (role) {
     case 'artist':
       return '아티스트';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,12 +13,13 @@ import {
   persistTokens,
 } from '@/features/auth/services/tokenStorage';
 import { authAPI } from '../services/api/auth';
+import type { UserRole } from '@/shared/types';
 
 interface User {
   id: string;
   email: string;
   name: string;
-  role: 'fan' | 'artist' | 'admin';
+  role: UserRole;
   avatar?: string;
   bio?: string;
   isVerified?: boolean;

--- a/src/features/admin/types/index.ts
+++ b/src/features/admin/types/index.ts
@@ -1,3 +1,5 @@
+import type { UserRole } from '@/shared/types';
+
 // Admin 관련 타입 정의
 export interface AdminUser {
   id: string;
@@ -86,7 +88,7 @@ export interface User {
   id: number;
   name: string;
   email: string;
-  role: 'fan' | 'artist' | 'admin';
+  role: UserRole;
   avatar?: string;
   joinDate: string;
   lastActivity: string;

--- a/src/features/auth/schemas/index.ts
+++ b/src/features/auth/schemas/index.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { UserRole } from '../../../shared/types';
+import { UserRole, USER_ROLE_VALUES } from '../../../shared/types';
 import { commonSchemas } from '../../../shared/utils/validation';
 
 // 로그인 스키마
@@ -16,7 +16,7 @@ export const signupSchema = z
     confirmPassword: z.string().min(1, '비밀번호 확인은 필수입니다'),
     username: commonSchemas.username,
     displayName: commonSchemas.displayName,
-    role: z.nativeEnum(UserRole).default(UserRole.FAN),
+    role: z.enum(USER_ROLE_VALUES).default(UserRole.FAN),
   })
   .refine(data => data.password === data.confirmPassword, {
     message: '비밀번호가 일치하지 않습니다',

--- a/src/features/community/types.ts
+++ b/src/features/community/types.ts
@@ -1,10 +1,12 @@
+import type { UserRole } from '@/shared/types';
+
 // 커뮤니티 도메인 타입 정의
 export interface CommunityUser {
   id: string;
   name: string;
   username: string;
   avatar?: string;
-  role: 'admin' | 'artist' | 'fan';
+  role: UserRole;
   isVerified?: boolean;
 }
 

--- a/src/features/community/types/index.ts
+++ b/src/features/community/types/index.ts
@@ -1,10 +1,12 @@
+import type { UserRole } from '@/shared/types';
+
 // 커뮤니티 관련 타입 정의
 
 export interface CommunityUser {
   id: string;
   username: string;
   name: string;
-  role: 'admin' | 'artist' | 'fan';
+  role: UserRole;
   avatar?: string;
   isVerified?: boolean;
 }

--- a/src/features/funding/schemas/index.ts
+++ b/src/features/funding/schemas/index.ts
@@ -1,14 +1,12 @@
 import { z } from 'zod';
 import { commonSchemas } from '../../../shared/utils/validation';
 import {
-  FundingProjectStatus,
-  PledgeStatus,
-  ExecutionStatus,
-  DistributionStatus,
-  DistributionRuleType,
-  EventType,
-  EventStatus,
-} from '../types';
+  DISTRIBUTION_RULE_TYPE_VALUES,
+  EXECUTION_STATUS_VALUES,
+  FUNDING_PROJECT_STATUS_VALUES,
+  PLEDGE_STATUS_VALUES,
+} from '../../../shared/types';
+import { EventStatus, EventType } from '../types';
 
 // 펀딩 프로젝트 생성 스키마
 export const createFundingProjectSchema = z
@@ -125,7 +123,7 @@ export const createPledgeSchema = z.object({
 
 // 후원 상태 업데이트 스키마
 export const updatePledgeStatusSchema = z.object({
-  status: z.nativeEnum(PledgeStatus),
+  status: z.enum(PLEDGE_STATUS_VALUES),
   refundAmount: z.number().int().min(0).optional(),
   refundReason: z.string().max(500).optional(),
   metadata: z.record(z.any()).optional(),
@@ -156,7 +154,7 @@ export const createExecutionSchema = z.object({
 
 // 집행 승인 스키마
 export const approveExecutionSchema = z.object({
-  status: z.nativeEnum(ExecutionStatus),
+  status: z.enum(EXECUTION_STATUS_VALUES),
   actualAmount: z.number().int().min(0).optional(),
   metadata: z.record(z.any()).optional(),
 });
@@ -178,7 +176,7 @@ export const uploadReceiptSchema = z.object({
 // 분배 규칙 스키마
 export const distributionRuleSchema = z
   .object({
-    type: z.nativeEnum(DistributionRuleType),
+    type: z.enum(DISTRIBUTION_RULE_TYPE_VALUES),
     percentage: z.number().min(0).max(100).optional(),
     fixedAmount: z.number().int().min(0).optional(),
     recipient: z.string().min(1, '수령자는 필수입니다'),
@@ -209,7 +207,7 @@ export const executeDistributionSchema = z.object({
 
 // 펀딩 프로젝트 필터 스키마
 export const fundingProjectFilterSchema = z.object({
-  status: z.array(z.nativeEnum(FundingProjectStatus)).optional(),
+  status: z.array(z.enum(FUNDING_PROJECT_STATUS_VALUES)).optional(),
   categoryId: commonSchemas.id.optional(),
   ownerId: commonSchemas.id.optional(),
   search: commonSchemas.search,
@@ -238,7 +236,7 @@ export const fundingProjectSortSchema = z.object({
 
 // 펀딩 프로젝트 상태 변경 스키마
 export const changeProjectStatusSchema = z.object({
-  status: z.nativeEnum(FundingProjectStatus),
+  status: z.enum(FUNDING_PROJECT_STATUS_VALUES),
   reason: z.string().max(500).optional(),
   metadata: z.record(z.any()).optional(),
 });

--- a/src/features/funding/types/index.ts
+++ b/src/features/funding/types/index.ts
@@ -1,15 +1,22 @@
-import { BaseEntity, User } from '../../../shared/types';
+import type {
+  BaseEntity,
+  DistributionItemStatus,
+  DistributionRuleType,
+  DistributionStatus,
+  ExecutionStatus,
+  FundingProjectStatus,
+  PledgeStatus,
+  User,
+} from '../../../shared/types';
 
-// 펀딩 프로젝트 상태
-export enum FundingProjectStatus {
-  DRAFT = 'draft', // 초안
-  COLLECTING = 'collecting', // 모금 중
-  SUCCEEDED = 'succeeded', // 성공
-  FAILED = 'failed', // 실패
-  EXECUTING = 'executing', // 집행 중
-  DISTRIBUTING = 'distributing', // 분배 중
-  CLOSED = 'closed', // 종료
-}
+export {
+  DistributionItemStatus,
+  DistributionRuleType,
+  DistributionStatus,
+  ExecutionStatus,
+  FundingProjectStatus,
+  PledgeStatus,
+} from '../../../shared/types';
 
 // 펀딩 프로젝트
 export interface FundingProject {
@@ -77,16 +84,6 @@ export interface Pledge extends BaseEntity {
   metadata: Record<string, any>;
 }
 
-// 후원 상태
-export enum PledgeStatus {
-  PENDING = 'pending', // 대기 중
-  AUTHORIZED = 'authorized', // 승인됨
-  CAPTURED = 'captured', // 결제 완료
-  REFUNDED = 'refunded', // 환불됨
-  FAILED = 'failed', // 실패
-  CANCELLED = 'cancelled', // 취소됨
-}
-
 // 집행 (Execution)
 export interface Execution extends BaseEntity {
   projectId: string;
@@ -99,14 +96,6 @@ export interface Execution extends BaseEntity {
   approvedAt?: Date;
   receipts: Receipt[];
   metadata: Record<string, any>;
-}
-
-// 집행 상태
-export enum ExecutionStatus {
-  PENDING = 'pending', // 대기 중
-  APPROVED = 'approved', // 승인됨
-  REJECTED = 'rejected', // 거부됨
-  COMPLETED = 'completed', // 완료됨
 }
 
 // 영수증
@@ -149,14 +138,6 @@ export interface Distribution extends BaseEntity {
   metadata: Record<string, any>;
 }
 
-// 분배 상태
-export enum DistributionStatus {
-  PENDING = 'pending', // 대기 중
-  CALCULATED = 'calculated', // 계산 완료
-  EXECUTED = 'executed', // 실행 완료
-  FAILED = 'failed', // 실패
-}
-
 // 분배 규칙
 export interface DistributionRule {
   type: DistributionRuleType;
@@ -165,15 +146,6 @@ export interface DistributionRule {
   recipient: string; // 수령자 (사용자 ID 또는 역할)
   description: string;
   priority: number; // 우선순위
-}
-
-// 분배 규칙 타입
-export enum DistributionRuleType {
-  OWNER = 'owner', // 프로젝트 소유자
-  PLATFORM = 'platform', // 플랫폼 수수료
-  ARTIST = 'artist', // 아티스트
-  CONTRIBUTOR = 'contributor', // 기여자
-  CUSTOM = 'custom', // 사용자 정의
 }
 
 // 분배 항목
@@ -186,14 +158,6 @@ export interface DistributionItem {
   executedAt?: Date;
   transactionId?: string;
   metadata: Record<string, any>;
-}
-
-// 분배 항목 상태
-export enum DistributionItemStatus {
-  PENDING = 'pending', // 대기 중
-  PROCESSING = 'processing', // 처리 중
-  COMPLETED = 'completed', // 완료됨
-  FAILED = 'failed', // 실패
 }
 
 // 카테고리

--- a/src/features/profile/types/profile.ts
+++ b/src/features/profile/types/profile.ts
@@ -1,4 +1,6 @@
-export type UserRole = 'admin' | 'artist' | 'fan';
+import type { UserRole } from '@/shared/types';
+
+export type { UserRole };
 
 export interface UserProfile {
   id: string;

--- a/src/hooks/useAuthRedirect.ts
+++ b/src/hooks/useAuthRedirect.ts
@@ -1,5 +1,6 @@
 import { useAuth } from '../contexts/AuthContext';
 import { useNavigate, useLocation } from 'react-router-dom';
+import type { UserRole } from '@/shared/types';
 
 /**
  * 인증이 필요한 액션을 처리하는 훅
@@ -20,7 +21,7 @@ export const useAuthRedirect = () => {
   const requireAuth = (
     action: () => void,
     redirectTo?: string,
-    requireRole?: 'artist' | 'admin' | 'fan',
+    requireRole?: UserRole,
   ) => {
     // 인증되지 않은 경우
     if (!isAuthenticated) {
@@ -48,7 +49,7 @@ export const useAuthRedirect = () => {
   const requireAuthAsync = async (
     action: () => Promise<void>,
     redirectTo?: string,
-    requireRole?: 'artist' | 'admin' | 'fan',
+    requireRole?: UserRole,
   ) => {
     // 인증되지 않은 경우
     if (!isAuthenticated) {
@@ -71,7 +72,7 @@ export const useAuthRedirect = () => {
    * 인증 상태를 확인하고 boolean 반환
    * @param requireRole - 특정 역할이 필요한 경우
    */
-  const checkAuth = (requireRole?: 'artist' | 'admin' | 'fan'): boolean => {
+  const checkAuth = (requireRole?: UserRole): boolean => {
     if (!isAuthenticated) {
       return false;
     }
@@ -112,7 +113,7 @@ export const useAuthRedirect = () => {
 };
 
 // 역할 표시명 변환 함수
-const getRoleDisplayName = (role: string): string => {
+const getRoleDisplayName = (role: UserRole): string => {
   switch (role) {
     case 'artist':
       return '아티스트';

--- a/src/lib/api/useAdminUsers.ts
+++ b/src/lib/api/useAdminUsers.ts
@@ -1,8 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { adminUserAPI } from '../../services/api/admin';
-import type { ApiResponse } from '@/shared/types';
+import type { ApiResponse, UserRole } from '@/shared/types';
 
-type AdminUserRole = 'admin' | 'artist' | 'fan';
+type AdminUserRole = UserRole;
 type AdminUserStatus = 'active' | 'inactive' | 'suspended';
 
 export interface AdminUser {
@@ -189,7 +189,13 @@ export const useUpdateUserRole = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ userId, role }: { userId: string; role: string }) => {
+    mutationFn: async ({
+      userId,
+      role,
+    }: {
+      userId: string;
+      role: AdminUserRole;
+    }) => {
       return await adminUserAPI.updateUserRole(userId, role);
     },
     onSuccess: () => {

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -1,16 +1,18 @@
+import type {
+  BaseEntity,
+  NotificationType,
+  UserRole,
+} from './index';
+
 /**
  * 공통 타입 정의
  */
 
 // 기본 엔티티 인터페이스
-export interface BaseEntity {
-  id: string | number;
-  createdAt: string;
-  updatedAt: string;
-}
+export type { BaseEntity };
 
 // 사용자 역할 타입
-export type UserRole = 'admin' | 'artist' | 'fan';
+export type { UserRole };
 
 // 사용자 상태 타입
 export type UserStatus = 'active' | 'inactive' | 'suspended' | 'pending';
@@ -42,17 +44,7 @@ export type PaymentMethod =
   | 'naver';
 
 // 알림 타입
-export type NotificationType =
-  | 'project_approved'
-  | 'project_rejected'
-  | 'project_completed'
-  | 'project_failed'
-  | 'payment_received'
-  | 'payment_failed'
-  | 'comment_received'
-  | 'like_received'
-  | 'follow_received'
-  | 'system_announcement';
+export type { NotificationType };
 
 // 파일 타입
 export type FileType =

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,28 +1,175 @@
+import type { Prisma } from '@prisma/client';
+
 export * from './api';
 
-// 공통 타입 정의
+export type { Prisma } from '@prisma/client';
+
 export interface BaseEntity {
   id: string;
-  createdAt: string;
-  updatedAt: string;
+  createdAt: Date | string;
+  updatedAt: Date | string;
 }
 
-export interface User extends BaseEntity {
-  email: string;
-  username: string;
-  displayName: string;
-  name: string;
-  role: UserRole;
-  avatar?: string;
-  bio?: string;
-  isActive: boolean;
-}
+type WithBaseEntity<T extends { createdAt: Date; updatedAt: Date }> = Omit<
+  T,
+  'createdAt' | 'updatedAt'
+> &
+  BaseEntity;
 
-export enum UserRole {
-  ADMIN = 'admin',
-  ARTIST = 'artist',
-  FAN = 'fan',
-}
+export type User = WithBaseEntity<Prisma.User>;
+
+export const USER_ROLE_VALUES = [
+  'admin',
+  'artist',
+  'fan',
+] as const satisfies readonly Prisma.UserRole[];
+export type UserRole = (typeof USER_ROLE_VALUES)[number];
+export const UserRole = {
+  ADMIN: USER_ROLE_VALUES[0],
+  ARTIST: USER_ROLE_VALUES[1],
+  FAN: USER_ROLE_VALUES[2],
+} as const satisfies Record<'ADMIN' | 'ARTIST' | 'FAN', UserRole>;
+
+export const NOTIFICATION_TYPE_VALUES = [
+  'info',
+  'success',
+  'warning',
+  'error',
+  'funding_update',
+  'project_update',
+  'community_update',
+] as const satisfies readonly Prisma.NotificationType[];
+export type NotificationType = (typeof NOTIFICATION_TYPE_VALUES)[number];
+export const NotificationType = {
+  INFO: NOTIFICATION_TYPE_VALUES[0],
+  SUCCESS: NOTIFICATION_TYPE_VALUES[1],
+  WARNING: NOTIFICATION_TYPE_VALUES[2],
+  ERROR: NOTIFICATION_TYPE_VALUES[3],
+  FUNDING_UPDATE: NOTIFICATION_TYPE_VALUES[4],
+  PROJECT_UPDATE: NOTIFICATION_TYPE_VALUES[5],
+  COMMUNITY_UPDATE: NOTIFICATION_TYPE_VALUES[6],
+} as const satisfies Record<
+  'INFO' | 'SUCCESS' | 'WARNING' | 'ERROR' | 'FUNDING_UPDATE' | 'PROJECT_UPDATE' | 'COMMUNITY_UPDATE',
+  NotificationType
+>;
+
+export type Notification = WithBaseEntity<Prisma.Notification>;
+
+export const FUNDING_PROJECT_STATUS_VALUES = [
+  'draft',
+  'collecting',
+  'succeeded',
+  'failed',
+  'executing',
+  'distributing',
+  'closed',
+] as const satisfies readonly Prisma.FundingProjectStatus[];
+export type FundingProjectStatus = (typeof FUNDING_PROJECT_STATUS_VALUES)[number];
+export const FundingProjectStatus = {
+  DRAFT: FUNDING_PROJECT_STATUS_VALUES[0],
+  COLLECTING: FUNDING_PROJECT_STATUS_VALUES[1],
+  SUCCEEDED: FUNDING_PROJECT_STATUS_VALUES[2],
+  FAILED: FUNDING_PROJECT_STATUS_VALUES[3],
+  EXECUTING: FUNDING_PROJECT_STATUS_VALUES[4],
+  DISTRIBUTING: FUNDING_PROJECT_STATUS_VALUES[5],
+  CLOSED: FUNDING_PROJECT_STATUS_VALUES[6],
+} as const satisfies Record<
+  'DRAFT' | 'COLLECTING' | 'SUCCEEDED' | 'FAILED' | 'EXECUTING' | 'DISTRIBUTING' | 'CLOSED',
+  FundingProjectStatus
+>;
+
+export const PLEDGE_STATUS_VALUES = [
+  'pending',
+  'authorized',
+  'captured',
+  'refunded',
+  'failed',
+  'cancelled',
+] as const satisfies readonly Prisma.PledgeStatus[];
+export type PledgeStatus = (typeof PLEDGE_STATUS_VALUES)[number];
+export const PledgeStatus = {
+  PENDING: PLEDGE_STATUS_VALUES[0],
+  AUTHORIZED: PLEDGE_STATUS_VALUES[1],
+  CAPTURED: PLEDGE_STATUS_VALUES[2],
+  REFUNDED: PLEDGE_STATUS_VALUES[3],
+  FAILED: PLEDGE_STATUS_VALUES[4],
+  CANCELLED: PLEDGE_STATUS_VALUES[5],
+} as const satisfies Record<
+  'PENDING' | 'AUTHORIZED' | 'CAPTURED' | 'REFUNDED' | 'FAILED' | 'CANCELLED',
+  PledgeStatus
+>;
+
+export const EXECUTION_STATUS_VALUES = [
+  'pending',
+  'approved',
+  'rejected',
+  'completed',
+] as const satisfies readonly Prisma.ExecutionStatus[];
+export type ExecutionStatus = (typeof EXECUTION_STATUS_VALUES)[number];
+export const ExecutionStatus = {
+  PENDING: EXECUTION_STATUS_VALUES[0],
+  APPROVED: EXECUTION_STATUS_VALUES[1],
+  REJECTED: EXECUTION_STATUS_VALUES[2],
+  COMPLETED: EXECUTION_STATUS_VALUES[3],
+} as const satisfies Record<
+  'PENDING' | 'APPROVED' | 'REJECTED' | 'COMPLETED',
+  ExecutionStatus
+>;
+
+export const DISTRIBUTION_STATUS_VALUES = [
+  'pending',
+  'calculated',
+  'executed',
+  'failed',
+] as const satisfies readonly Prisma.DistributionStatus[];
+export type DistributionStatus = (typeof DISTRIBUTION_STATUS_VALUES)[number];
+export const DistributionStatus = {
+  PENDING: DISTRIBUTION_STATUS_VALUES[0],
+  CALCULATED: DISTRIBUTION_STATUS_VALUES[1],
+  EXECUTED: DISTRIBUTION_STATUS_VALUES[2],
+  FAILED: DISTRIBUTION_STATUS_VALUES[3],
+} as const satisfies Record<
+  'PENDING' | 'CALCULATED' | 'EXECUTED' | 'FAILED',
+  DistributionStatus
+>;
+
+export const DISTRIBUTION_RULE_TYPE_VALUES = [
+  'owner',
+  'platform',
+  'artist',
+  'contributor',
+  'custom',
+] as const satisfies readonly Prisma.DistributionRuleType[];
+export type DistributionRuleType = (typeof DISTRIBUTION_RULE_TYPE_VALUES)[number];
+export const DistributionRuleType = {
+  OWNER: DISTRIBUTION_RULE_TYPE_VALUES[0],
+  PLATFORM: DISTRIBUTION_RULE_TYPE_VALUES[1],
+  ARTIST: DISTRIBUTION_RULE_TYPE_VALUES[2],
+  CONTRIBUTOR: DISTRIBUTION_RULE_TYPE_VALUES[3],
+  CUSTOM: DISTRIBUTION_RULE_TYPE_VALUES[4],
+} as const satisfies Record<
+  'OWNER' | 'PLATFORM' | 'ARTIST' | 'CONTRIBUTOR' | 'CUSTOM',
+  DistributionRuleType
+>;
+
+export const DISTRIBUTION_ITEM_STATUS_VALUES = [
+  'pending',
+  'processing',
+  'completed',
+  'failed',
+] as const satisfies readonly Prisma.DistributionItemStatus[];
+export type DistributionItemStatus = (typeof DISTRIBUTION_ITEM_STATUS_VALUES)[number];
+export const DistributionItemStatus = {
+  PENDING: DISTRIBUTION_ITEM_STATUS_VALUES[0],
+  PROCESSING: DISTRIBUTION_ITEM_STATUS_VALUES[1],
+  COMPLETED: DISTRIBUTION_ITEM_STATUS_VALUES[2],
+  FAILED: DISTRIBUTION_ITEM_STATUS_VALUES[3],
+} as const satisfies Record<
+  'PENDING' | 'PROCESSING' | 'COMPLETED' | 'FAILED',
+  DistributionItemStatus
+>;
+
+export type NotificationEntity = Notification;
 
 export interface QueryParams {
   page?: number;
@@ -70,21 +217,6 @@ export interface FileUpload {
 }
 
 // 알림 타입
-export interface Notification extends BaseEntity {
-  userId: string;
-  title: string;
-  message: string;
-  type: NotificationType;
-  isRead: boolean;
+export interface NotificationPayload extends NotificationEntity {
   data?: Record<string, unknown>;
-}
-
-export enum NotificationType {
-  INFO = 'info',
-  SUCCESS = 'success',
-  WARNING = 'warning',
-  ERROR = 'error',
-  FUNDING_UPDATE = 'funding_update',
-  PROJECT_UPDATE = 'project_update',
-  COMMUNITY_UPDATE = 'community_update',
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,5 @@
 import { getStoredAccessToken } from '@/features/auth/services/tokenStorage';
-
-export type UserRole = 'fan' | 'artist' | 'admin';
+import type { UserRole } from '@/shared/types';
 
 export interface SignupData {
   email: string;
@@ -105,7 +104,7 @@ export const isAuthenticated = (): boolean => {
 };
 
 // 사용자 역할 확인
-export const getUserRole = (): string | null => {
+export const getUserRole = (): UserRole | null => {
   const user = getCurrentUser();
   return user?.role || null;
 };


### PR DESCRIPTION
## Summary
- introduce an initial Prisma schema describing users, funding projects, pledges, executions, distributions, and supporting enums
- refactor shared types and UI/auth/admin/community modules to consume Prisma-provided enum values and value lists
- refresh database documentation and README to highlight the PostgreSQL + Prisma workflow replacing prior MongoDB guidance

## Testing
- `npm run typecheck` *(fails: missing type definition packages because dependencies are not installed in the sandbox; npm install blocked when fetching @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_b_68d6a68dbd888326a194c3a6cda112fa