### PR TITLE
feat: replace community module with prisma data layer

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -740,8 +740,10 @@ model CommunityPostComment {
   authorName String
   content    String
   createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
 
   replies    CommunityPostReply[]
+  reactions  CommunityCommentReaction[]
 
   @@index([postId, createdAt])
 }
@@ -755,6 +757,9 @@ model CommunityPostReply {
   authorName String
   content    String
   createdAt  DateTime      @default(now())
+  updatedAt  DateTime      @updatedAt
+
+  reactions  CommunityCommentReaction[]
 
   @@index([commentId, createdAt])
 }
@@ -781,6 +786,22 @@ model CommunityPostReport {
   reportedAt DateTime      @default(now())
 
   @@index([postId, reportedAt])
+}
+
+model CommunityCommentReaction {
+  id        String        @id @default(cuid())
+  commentId String?
+  comment   CommunityPostComment? @relation(fields: [commentId], references: [id])
+  replyId   String?
+  reply     CommunityPostReply?   @relation(fields: [replyId], references: [id])
+  userId    String
+  user      User          @relation(fields: [userId], references: [id])
+  type      ReactionType
+  createdAt DateTime      @default(now())
+
+  @@unique([commentId, userId])
+  @@unique([replyId, userId])
+  @@index([userId, createdAt])
 }
 
 model Track {

--- a/server/routes/community.js
+++ b/server/routes/community.js
@@ -1,13 +1,14 @@
 const express = require('express');
-const mongoose = require('mongoose');
 const router = express.Router();
 const auth = require('../middleware/auth');
 const communityController = require('../src/controllers/communityController');
 
+const isValidId = value => typeof value === 'string' && value.trim().length > 0;
+
 const validateObjectIdParam = (param, message) => (req, res, next) => {
   const value = req.params[param];
 
-  if (!mongoose.Types.ObjectId.isValid(value)) {
+  if (!isValidId(value)) {
     return res.status(400).json({
       success: false,
       message,

--- a/server/src/controllers/communityController.js
+++ b/server/src/controllers/communityController.js
@@ -50,7 +50,10 @@ const getRecentPosts = handleController(async (req, res) => {
 });
 
 const getPostById = handleController(async (req, res) => {
-  const post = await communityService.getPostById(req.params.id);
+  const post = await communityService.getPostById(
+    req.params.id,
+    req.user?._id ?? null,
+  );
   res.json({
     success: true,
     data: post,
@@ -141,6 +144,7 @@ const getComments = handleController(async (req, res) => {
   const { comments, pagination } = await communityService.getComments(
     req.params.id,
     req.query,
+    req.user?._id ?? null,
   );
   res.json({
     success: true,

--- a/server/src/lib/prisma.js
+++ b/server/src/lib/prisma.js
@@ -1,0 +1,19 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prisma;
+
+if (!global.__PRISMA_CLIENT__) {
+  prisma = new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+  });
+
+  if (process.env.NODE_ENV !== 'production') {
+    global.__PRISMA_CLIENT__ = prisma;
+  }
+} else {
+  prisma = global.__PRISMA_CLIENT__;
+}
+
+module.exports = {
+  prisma,
+};

--- a/server/src/repositories/communityRepository.js
+++ b/server/src/repositories/communityRepository.js
@@ -1,67 +1,558 @@
-const CommunityPost = require('../../models/CommunityPost');
+const { prisma } = require('../lib/prisma');
+const { Prisma } = require('@prisma/client');
 
-const AUTHOR_FIELDS = 'name role avatar';
+const AUTHOR_SELECT = {
+  id: true,
+  name: true,
+  role: true,
+  avatar: true,
+};
 
-const applyAuthorPopulation = (query, { includeComments = false } = {}) => {
-  let populatedQuery = query.populate('author', AUTHOR_FIELDS);
+const REACTION_TYPE = {
+  like: 'LIKE',
+  dislike: 'DISLIKE',
+};
 
-  if (includeComments) {
-    populatedQuery = populatedQuery
-      .populate('comments.author', AUTHOR_FIELDS)
-      .populate('comments.replies.author', AUTHOR_FIELDS);
+const buildPostWhere = ({ search, category }) => {
+  const where = {
+    isActive: true,
+  };
+
+  if (category && category !== 'all') {
+    where.category = category;
   }
 
-  return populatedQuery;
+  if (search) {
+    where.OR = [
+      { title: { contains: search, mode: 'insensitive' } },
+      { content: { contains: search, mode: 'insensitive' } },
+      { tags: { has: search } },
+    ];
+  }
+
+  return where;
 };
 
-const findPosts = async ({ query, sort, skip, limit }) => {
-  return applyAuthorPopulation(
-    CommunityPost.find(query).sort(sort).skip(skip).limit(limit),
-    { includeComments: false },
-  );
+const buildPostOrderBy = sortBy => {
+  switch (sortBy) {
+    case 'popular':
+      return [
+        { reactions: { _count: 'desc' } },
+        { viewCount: 'desc' },
+        { createdAt: 'desc' },
+      ];
+    case 'oldest':
+      return [{ createdAt: 'asc' }];
+    case 'latest':
+    default:
+      return [{ createdAt: 'desc' }];
+  }
 };
 
-const countPosts = async query => {
-  return CommunityPost.countDocuments(query);
+const mapReactions = (reactions = [], currentUserId = null) => {
+  const likes = [];
+  const dislikes = [];
+
+  reactions.forEach(reaction => {
+    if (reaction.type === 'LIKE') {
+      likes.push(reaction.userId);
+    } else if (reaction.type === 'DISLIKE') {
+      dislikes.push(reaction.userId);
+    }
+  });
+
+  const userReaction = currentUserId
+    ? likes.includes(currentUserId)
+      ? 'LIKE'
+      : dislikes.includes(currentUserId)
+        ? 'DISLIKE'
+        : null
+    : null;
+
+  return {
+    likes,
+    dislikes,
+    likeCount: likes.length,
+    dislikeCount: dislikes.length,
+    userReaction,
+    isLiked: userReaction === 'LIKE',
+    isDisliked: userReaction === 'DISLIKE',
+  };
 };
 
-const findPopularPosts = async limit => {
-  return applyAuthorPopulation(
-    CommunityPost.find({ isActive: true })
-      .sort({ likes: -1, viewCount: -1 })
-      .limit(limit),
-    { includeComments: false },
-  );
+const mapReply = (reply, currentUserId) => ({
+  id: reply.id,
+  authorId: reply.authorId,
+  authorName: reply.authorName,
+  author: reply.author,
+  content: reply.content,
+  createdAt: reply.createdAt,
+  updatedAt: reply.updatedAt,
+  ...mapReactions(reply.reactions ?? [], currentUserId),
+});
+
+const mapComment = (comment, currentUserId) => ({
+  id: comment.id,
+  postId: comment.postId,
+  authorId: comment.authorId,
+  authorName: comment.authorName,
+  author: comment.author,
+  content: comment.content,
+  createdAt: comment.createdAt,
+  updatedAt: comment.updatedAt,
+  ...mapReactions(comment.reactions ?? [], currentUserId),
+  replies: (comment.replies ?? [])
+    .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+    .map(reply => mapReply(reply, currentUserId)),
+});
+
+const mapPost = (post, { includeComments = false, currentUserId = null } = {}) => ({
+  id: post.id,
+  title: post.title,
+  content: post.content,
+  authorId: post.authorId,
+  authorName: post.authorName,
+  author: post.author,
+  category: post.category,
+  tags: post.tags,
+  images: post.images,
+  isReported: post.isReported,
+  isActive: post.isActive,
+  deletedAt: post.deletedAt,
+  viewCount: post.viewCount,
+  createdAt: post.createdAt,
+  updatedAt: post.updatedAt,
+  ...mapReactions(post.reactions ?? [], currentUserId),
+  comments: includeComments
+    ? post.comments
+        .sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+        .map(comment => mapComment(comment, currentUserId))
+    : undefined,
+});
+
+const findPosts = async ({ search, category, sortBy, skip, limit, currentUserId }) => {
+  const posts = await prisma.communityPost.findMany({
+    where: buildPostWhere({ search, category }),
+    orderBy: buildPostOrderBy(sortBy),
+    skip,
+    take: limit,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return posts.map(post => mapPost(post, { includeComments: false, currentUserId }));
 };
 
-const findRecentPosts = async limit => {
-  return applyAuthorPopulation(
-    CommunityPost.find({ isActive: true }).sort({ createdAt: -1 }).limit(limit),
-    { includeComments: false },
-  );
+const countPosts = async ({ search, category }) => {
+  return prisma.communityPost.count({
+    where: buildPostWhere({ search, category }),
+  });
 };
 
-const findPostById = async (id, { includeComments = false } = {}) => {
-  return applyAuthorPopulation(CommunityPost.findById(id), { includeComments });
+const findPopularPosts = async ({ limit, currentUserId }) => {
+  const posts = await prisma.communityPost.findMany({
+    where: { isActive: true },
+    orderBy: [
+      { reactions: { _count: 'desc' } },
+      { viewCount: 'desc' },
+      { createdAt: 'desc' },
+    ],
+    take: limit,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return posts.map(post => mapPost(post, { includeComments: false, currentUserId }));
 };
 
-const findPostDocumentById = async id => {
-  return CommunityPost.findById(id);
+const findRecentPosts = async ({ limit, currentUserId }) => {
+  const posts = await prisma.communityPost.findMany({
+    where: { isActive: true },
+    orderBy: [{ createdAt: 'desc' }],
+    take: limit,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return posts.map(post => mapPost(post, { includeComments: false, currentUserId }));
+};
+
+const findPostById = async (id, { includeComments = false, currentUserId = null } = {}) => {
+  const post = await prisma.communityPost.findUnique({
+    where: { id },
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+      comments: includeComments
+        ? {
+            orderBy: { createdAt: 'asc' },
+            include: {
+              author: { select: AUTHOR_SELECT },
+              reactions: { select: { userId: true, type: true } },
+              replies: {
+                orderBy: { createdAt: 'asc' },
+                include: {
+                  author: { select: AUTHOR_SELECT },
+                  reactions: { select: { userId: true, type: true } },
+                },
+              },
+            },
+          }
+        : false,
+    },
+  });
+
+  if (!post) {
+    return null;
+  }
+
+  return mapPost(post, { includeComments, currentUserId });
+};
+
+const incrementPostView = async id => {
+  const result = await prisma.communityPost.update({
+    where: { id },
+    data: { viewCount: { increment: 1 } },
+    select: { viewCount: true },
+  });
+
+  return result.viewCount;
 };
 
 const createPost = async data => {
-  const post = new CommunityPost(data);
-  return post.save();
+  const post = await prisma.communityPost.create({
+    data,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return mapPost(post);
 };
 
-const savePost = async post => {
-  return post.save();
+const updatePost = async (id, data) => {
+  const post = await prisma.communityPost.update({
+    where: { id },
+    data,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return mapPost(post);
 };
 
-const findCommentsByPostId = async id => {
-  return applyAuthorPopulation(CommunityPost.findById(id).select('comments'), {
-    includeComments: true,
-  }).lean();
+const softDeletePost = async id => {
+  await prisma.communityPost.update({
+    where: { id },
+    data: {
+      isActive: false,
+      deletedAt: new Date(),
+    },
+  });
+};
+
+const upsertPostReaction = async (postId, userId, reaction) => {
+  const reactionType = REACTION_TYPE[reaction];
+
+  if (!reactionType) {
+    throw new Prisma.PrismaClientValidationError('Invalid reaction type');
+  }
+
+  return prisma.$transaction(async tx => {
+    await tx.communityPostReaction.deleteMany({
+      where: { postId, userId },
+    });
+
+    if (reactionType) {
+      await tx.communityPostReaction.create({
+        data: {
+          postId,
+          userId,
+          type: reactionType,
+        },
+      });
+    }
+
+    const reactions = await tx.communityPostReaction.findMany({
+      where: { postId },
+      select: { userId: true, type: true },
+    });
+
+    return mapReactions(reactions, userId);
+  });
+};
+
+const removePostReaction = async (postId, userId) => {
+  await prisma.communityPostReaction.deleteMany({
+    where: { postId, userId },
+  });
+
+  const reactions = await prisma.communityPostReaction.findMany({
+    where: { postId },
+    select: { userId: true, type: true },
+  });
+
+  return mapReactions(reactions, userId);
+};
+
+const createPostReport = async (postId, reporterId, reason) => {
+  await prisma.communityPostReport.create({
+    data: {
+      postId,
+      reporterId,
+      reason,
+    },
+  });
+
+  const reportCount = await prisma.communityPostReport.count({
+    where: { postId },
+  });
+
+  if (reportCount >= 5) {
+    await prisma.communityPost.update({
+      where: { id: postId },
+      data: {
+        isActive: false,
+        isReported: true,
+      },
+    });
+  }
+};
+
+const hasUserReportedPost = async (postId, reporterId) => {
+  const existing = await prisma.communityPostReport.findFirst({
+    where: { postId, reporterId },
+    select: { id: true },
+  });
+
+  return Boolean(existing);
+};
+
+const createComment = async ({
+  postId,
+  authorId,
+  authorName,
+  content,
+}) => {
+  const comment = await prisma.communityPostComment.create({
+    data: {
+      postId,
+      authorId,
+      authorName,
+      content,
+    },
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+      replies: {
+        include: {
+          author: { select: AUTHOR_SELECT },
+          reactions: { select: { userId: true, type: true } },
+        },
+      },
+    },
+  });
+
+  return mapComment(comment, null);
+};
+
+const createReply = async ({
+  commentId,
+  authorId,
+  authorName,
+  content,
+}) => {
+  const reply = await prisma.communityPostReply.create({
+    data: {
+      commentId,
+      authorId,
+      authorName,
+      content,
+    },
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return mapReply(reply, null);
+};
+
+const updateCommentContent = async (id, content) => {
+  const comment = await prisma.communityPostComment.update({
+    where: { id },
+    data: { content },
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+      replies: {
+        include: {
+          author: { select: AUTHOR_SELECT },
+          reactions: { select: { userId: true, type: true } },
+        },
+      },
+    },
+  });
+
+  return mapComment(comment, null);
+};
+
+const updateReplyContent = async (id, content) => {
+  const reply = await prisma.communityPostReply.update({
+    where: { id },
+    data: { content },
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+    },
+  });
+
+  return mapReply(reply, null);
+};
+
+const deleteComment = async id => {
+  await prisma.communityPostReply.deleteMany({ where: { commentId: id } });
+  await prisma.communityCommentReaction.deleteMany({ where: { commentId: id } });
+  await prisma.communityPostComment.delete({ where: { id } });
+};
+
+const deleteReply = async id => {
+  await prisma.communityCommentReaction.deleteMany({ where: { replyId: id } });
+  await prisma.communityPostReply.delete({ where: { id } });
+};
+
+const findCommentsByPostId = async ({
+  postId,
+  skip,
+  take,
+  order = 'desc',
+  currentUserId,
+}) => {
+  const comments = await prisma.communityPostComment.findMany({
+    where: { postId },
+    orderBy: { createdAt: order === 'desc' ? 'desc' : 'asc' },
+    skip,
+    take,
+    include: {
+      author: { select: AUTHOR_SELECT },
+      reactions: { select: { userId: true, type: true } },
+      replies: {
+        orderBy: { createdAt: 'asc' },
+        include: {
+          author: { select: AUTHOR_SELECT },
+          reactions: { select: { userId: true, type: true } },
+        },
+      },
+    },
+  });
+
+  const total = await prisma.communityPostComment.count({ where: { postId } });
+
+  return {
+    comments: comments.map(comment => mapComment(comment, currentUserId)),
+    total,
+  };
+};
+
+const upsertCommentReaction = async ({
+  commentId,
+  replyId = null,
+  userId,
+  reaction,
+}) => {
+  const reactionType = REACTION_TYPE[reaction];
+
+  if (!reactionType) {
+    throw new Prisma.PrismaClientValidationError('Invalid reaction type');
+  }
+
+  return prisma.$transaction(async tx => {
+    if (commentId) {
+      await tx.communityCommentReaction.deleteMany({
+        where: { commentId, userId },
+      });
+
+      await tx.communityCommentReaction.create({
+        data: {
+          commentId,
+          userId,
+          type: reactionType,
+        },
+      });
+
+      const reactions = await tx.communityCommentReaction.findMany({
+        where: { commentId },
+      });
+
+      return mapReactions(reactions, userId);
+    }
+
+    await tx.communityCommentReaction.deleteMany({
+      where: { replyId, userId },
+    });
+
+    await tx.communityCommentReaction.create({
+      data: {
+        replyId,
+        userId,
+        type: reactionType,
+      },
+    });
+
+    const reactions = await tx.communityCommentReaction.findMany({
+      where: { replyId },
+    });
+
+    return mapReactions(reactions, userId);
+  });
+};
+
+const removeCommentReaction = async ({ commentId = null, replyId = null, userId }) => {
+  await prisma.communityCommentReaction.deleteMany({
+    where: {
+      commentId,
+      replyId,
+      userId,
+    },
+  });
+
+  const reactions = await prisma.communityCommentReaction.findMany({
+    where: commentId ? { commentId } : { replyId },
+  });
+
+  return mapReactions(reactions, userId);
+};
+
+const findCommentRecordById = async id => {
+  return prisma.communityPostComment.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      postId: true,
+      authorId: true,
+    },
+  });
+};
+
+const findReplyRecordById = async id => {
+  return prisma.communityPostReply.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      commentId: true,
+      authorId: true,
+      comment: { select: { postId: true } },
+    },
+  });
 };
 
 module.exports = {
@@ -70,8 +561,23 @@ module.exports = {
   findPopularPosts,
   findRecentPosts,
   findPostById,
-  findPostDocumentById,
+  incrementPostView,
   createPost,
-  savePost,
+  updatePost,
+  softDeletePost,
+  upsertPostReaction,
+  removePostReaction,
+  createPostReport,
+  createComment,
+  createReply,
+  updateCommentContent,
+  updateReplyContent,
+  deleteComment,
+  deleteReply,
   findCommentsByPostId,
+  upsertCommentReaction,
+  removeCommentReaction,
+  findCommentRecordById,
+  findReplyRecordById,
+  hasUserReportedPost,
 };


### PR DESCRIPTION
## Summary
- replace the community repository with Prisma-based queries that materialize post, comment, and reaction view models
- reimplement the community service to operate on Prisma data, map display categories, and normalize reaction/report workflows
- add a shared Prisma client helper, extend the Prisma schema for comment reactions, and simplify community route id validation

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_68d6a68acacc8326844387b881144f13